### PR TITLE
fix: Lint ignore typescript blocks

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -17,6 +17,6 @@ BasedOnStyles = Vale #, RedHat
 
 # ignore yaml blocks
 [*]
-BlockIgnores = (?s) *(\x60\x60\x60yaml.*?\x60\x60\x60)
-
+BlockIgnores = (?s) *(\x60\x60\x60yaml.*?\x60\x60\x60), \
+(?s) *(\x60\x60\x60typescript.*?\x60\x60\x60)
 


### PR DESCRIPTION
fix lint failures for js code samples