### PR TITLE
chore:  Update CODEOWNERS to include @opentdf/security for helping with Dependabot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @opentdf/maintainers
+
+# @opentdf/security added on 2025-02-04 package.json,package-lock.json
+package.json @opentdf/maintainers @opentdf/security
+package-lock.json @opentdf/maintainers @opentdf/security


### PR DESCRIPTION
This PR updates CODEOWNERS to include @opentdf/security for files:
 * package.json
 * package-lock.json