### PR TITLE
chore(docs): remove stale sdk feature info and link to feature matrix…

### DIFF
--- a/docs/sdks/overview.mdx
+++ b/docs/sdks/overview.mdx
@@ -6,40 +6,7 @@ sidebar_position: 1
 
 OpenTDF supports native SDKs in the Go, Java and JavaScript languages. 
 
-## Supported Features
-
-|                            | Go       | Java     | C++      | JavaScript |
-| :------------------------- | -------- | -------- | -------- | ---------- |
-| **Lifecycle**              | Beta     | Alpha    | Alpha    | Alpha      |
-| **Support**[^101]          | Official | Official | Official | Official   |
-|                            |          |          |          |            |
-| **Encrypt/Decrypt**[^103]  | Stable   | Unstable | Planned  | Unstable   |
-| - ZTDF[^110]               | Stable   | Unstable | Planned  | Unstable   |
-| - NanoTDF[^111]            | Stable   | Planned  | Planned  | Unstable   |
-| - ABAC[^112]               | Stable   | Unstable | Planned  | Unstable   |
-| - Dissem[^113]             | Unstable | Unstable | Planned  | Unstable   |
-|                            |          |          |          |            |
-| **Service APIs**[^105]     | Stable   | Stable   | Planned  | Planned    |
-| - Authorization [^120]     |          |          |          |            |
-| - Key Access Server [^121] |          |          |          |            |
-| - Policy: Attributes[^130] |          |          |          |            |
-
-[^101]: Support is the level of support for the SDK (Official, Community).
-[^103]: Encrypt is the ability to encrypt data.
-[^105]: Service APIs are APIs that are provided by the library to interact with the service.
-
-<!-- SDK Footnotes -->
-
-[^110]: Support for the [Zero Trust Data Format](https://github.com/opentdf/spec/tree/main/schema/tdf) utilizing JSON manifests.
-[^111]: Support for the [Nano Trusted Data Format](https://github.com/opentdf/spec/tree/main/schema/nanotdf).
-[^112]: ABAC is Attribute Based Access Control.
-[^113]: Dissem is Dissemination List (i.e. email lists).
-
-<!-- Service Footnotes -->
-
-[^120]: Authorization APIs for managing authorization policies.
-[^121]: Key Access Server (KAS) APIs for accessing key management.
-[^130]: APIs for managing policy attributes [proto](https://github.com/opentdf/platform/blob/main/service/policy/attributes/attributes.proto).
+Please refer to the [SDK Feature Matrix](../appendix/matrix.mdx#sdk) in the Appendix for the supported features in each SDK.
 
 ## Repositories
 


### PR DESCRIPTION
… instead

we had outdated info about our SDKs in the SDK section. we repeat this info (features supported) in the feature matrix section, so to avoid confusion and needing to doubly maintain it i just refer to it in the SDK section and deleted the stale info. 