### PR TITLE
chore(docs): Add policy to OpenAPI client section

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,9 +9,15 @@ import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import matter from "gray-matter";
 import listRemote from "./docusaurus-lib-list-remote";
-import { openApiSpecs } from "./preprocessing";
+import { preprocessOpenApiSpecs, openApiSpecs } from './src/openapi/preprocessing';
 import languageTabs from "./openapi-generated-clients";
 import { getSpecDocumentationPlugins } from './src/utils/spec-documentation';
+
+// Execute the preprocessing function for OpenAPI specs
+preprocessOpenApiSpecs().catch(error => {
+    console.error('Failed to preprocess OpenAPI specs:', error);
+    process.exit(1);
+});
 
 const otdfctl = listRemote.createRepo("opentdf", "otdfctl", "main");
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "gen-api-docs-all": "docusaurus gen-api-docs all --all-versions",
     "gen-api-docs-clean": "docusaurus clean-api-docs all",
-    "check-vendored-yaml": "tsx scripts/check-vendored-yaml.ts",
-    "update-vendored-yaml": "tsx scripts/update-vendored-yaml.ts"
+    "check-vendored-yaml": "tsx src/openapi/check-vendored-yaml.ts",
+    "update-vendored-yaml": "tsx src/openapi/update-vendored-yaml.ts"
   },
   "dependencies": {
     "@docusaurus/core": "^3.6.3",

--- a/specs/policy/actions/actions.openapi.yaml
+++ b/specs/policy/actions/actions.openapi.yaml
@@ -309,8 +309,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -463,7 +469,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: Deprecated
+          description: Deprecated KAS grants for the attribute. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -650,7 +656,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -897,9 +903,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: |-
-            Deprecated
-             list of key access servers
+          description: Deprecated KAS grants for the value. Use kas_keys instead.
         fqn:
           type: string
           title: fqn

--- a/specs/policy/kasregistry/key_access_server_registry.openapi.yaml
+++ b/specs/policy/kasregistry/key_access_server_registry.openapi.yaml
@@ -224,6 +224,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServerGrantsResponse'
+      deprecated: true
   /policy.kasregistry.KeyAccessServerRegistryService/CreateKey:
     post:
       tags:
@@ -478,6 +479,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.kasregistry.GetBaseKeyResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyMappings:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: ListKeyMappings
+      description: Request to list key mappings in the Key Access Service.
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyMappings
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.ListKeyMappingsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.ListKeyMappingsResponse'
 components:
   schemas:
     common.MetadataUpdateEnum:
@@ -598,8 +635,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -726,6 +769,10 @@ components:
           title: provider_config
           description: Optional Configuration for the key provider
           $ref: '#/components/schemas/policy.KeyProviderConfig'
+        legacy:
+          type: boolean
+          title: legacy
+          description: Optional Indicates a key may be found in TDFs without key identifiers
         metadata:
           title: metadata
           description: Common metadata fields
@@ -1097,7 +1144,7 @@ components:
             Required The algorithm to be used for the key
             The key_algorithm must be one of the defined values.:
             ```
-            this in [1, 2, 3, 4]
+            this in [1, 2, 3, 4, 5]
             ```
 
           $ref: '#/components/schemas/policy.Algorithm'
@@ -1123,6 +1170,10 @@ components:
           type: string
           title: provider_config_id
           description: Optional Configuration ID for the key provider, if applicable
+        legacy:
+          type: boolean
+          title: legacy
+          description: Optional Whether the key is a legacy key
         metadata:
           title: metadata
           description: Common metadata Mutable metadata for the key
@@ -1417,6 +1468,35 @@ components:
       title: KeyAccessServerGrants
       additionalProperties: false
       description: Deprecated
+    policy.kasregistry.KeyMapping:
+      type: object
+      properties:
+        kid:
+          type: string
+          title: kid
+        kasUri:
+          type: string
+          title: kas_uri
+        namespaceMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/policy.kasregistry.MappedPolicyObject'
+          title: namespace_mappings
+          description: List of namespaces mapped to the key
+        attributeMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/policy.kasregistry.MappedPolicyObject'
+          title: attribute_mappings
+          description: List of attribute definitions mapped to the key
+        valueMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/policy.kasregistry.MappedPolicyObject'
+          title: value_mappings
+          description: List of attribute values mapped to the key
+      title: KeyMapping
+      additionalProperties: false
     policy.kasregistry.ListKeyAccessServerGrantsRequest:
       type: object
       properties:
@@ -1508,6 +1588,47 @@ components:
           $ref: '#/components/schemas/policy.PageResponse'
       title: ListKeyAccessServersResponse
       additionalProperties: false
+    policy.kasregistry.ListKeyMappingsRequest:
+      type: object
+      oneOf:
+        - properties:
+            id:
+              type: string
+              title: id
+              format: uuid
+              description: The unique identifier of the key to retrieve
+          title: id
+          required:
+            - id
+        - properties:
+            key:
+              title: key
+              $ref: '#/components/schemas/policy.kasregistry.KasKeyIdentifier'
+          title: key
+          required:
+            - key
+      properties:
+        pagination:
+          title: pagination
+          description: Pagination request for the list of keys
+          $ref: '#/components/schemas/policy.PageRequest'
+      title: ListKeyMappingsRequest
+      additionalProperties: false
+    policy.kasregistry.ListKeyMappingsResponse:
+      type: object
+      properties:
+        keyMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/policy.kasregistry.KeyMapping'
+          title: key_mappings
+          description: The list of key mappings
+        pagination:
+          title: pagination
+          description: Pagination response for the list of keys
+          $ref: '#/components/schemas/policy.PageResponse'
+      title: ListKeyMappingsResponse
+      additionalProperties: false
     policy.kasregistry.ListKeysRequest:
       type: object
       oneOf:
@@ -1546,10 +1667,15 @@ components:
             Filter keys by algorithm
             The key_algorithm must be one of the defined values.:
             ```
-            this in [0, 1, 2, 3, 4]
+            this in [0, 1, 2, 3, 4, 5]
             ```
 
           $ref: '#/components/schemas/policy.Algorithm'
+        legacy:
+          type: boolean
+          title: legacy
+          description: Optional Filter for legacy keys
+          nullable: true
         pagination:
           title: pagination
           description: Optional Pagination request for the list of keys
@@ -1733,6 +1859,19 @@ components:
           $ref: '#/components/schemas/policy.PageResponse'
       title: ListPublicKeysResponse
       additionalProperties: false
+    policy.kasregistry.MappedPolicyObject:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The unique identifier of the policy object
+        fqn:
+          type: string
+          title: fqn
+          description: The fully qualified name of the policy object
+      title: MappedPolicyObject
+      additionalProperties: false
     policy.kasregistry.RotateKeyRequest:
       type: object
       oneOf:
@@ -1790,7 +1929,7 @@ components:
             Required
             The key_algorithm must be one of the defined values.:
             ```
-            this in [1, 2, 3, 4]
+            this in [1, 2, 3, 4, 5]
             ```
 
           $ref: '#/components/schemas/policy.Algorithm'

--- a/specs/policy/keymanagement/key_management.openapi.yaml
+++ b/specs/policy/keymanagement/key_management.openapi.yaml
@@ -246,6 +246,9 @@ components:
       additionalProperties: false
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local

--- a/specs/policy/namespaces/namespaces.openapi.yaml
+++ b/specs/policy/namespaces/namespaces.openapi.yaml
@@ -216,6 +216,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.namespaces.AssignKeyAccessServerToNamespaceResponse'
+      deprecated: true
   /policy.namespaces.NamespaceService/RemoveKeyAccessServerFromNamespace:
     post:
       tags:
@@ -251,6 +252,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.namespaces.RemoveKeyAccessServerFromNamespaceResponse'
+      deprecated: true
   /policy.namespaces.NamespaceService/AssignPublicKeyToNamespace:
     post:
       tags:
@@ -436,8 +438,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -643,7 +651,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -942,6 +950,7 @@ components:
           description: Required
       title: NamespaceKeyAccessServer
       additionalProperties: false
+      description: Deprecated
     policy.namespaces.RemoveKeyAccessServerFromNamespaceRequest:
       type: object
       properties:

--- a/specs/policy/objects.openapi.yaml
+++ b/specs/policy/objects.openapi.yaml
@@ -122,8 +122,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -283,6 +289,10 @@ components:
           title: provider_config
           description: Optional Configuration for the key provider
           $ref: '#/components/schemas/policy.KeyProviderConfig'
+        legacy:
+          type: boolean
+          title: legacy
+          description: Optional Indicates a key may be found in TDFs without key identifiers
         metadata:
           title: metadata
           description: Common metadata fields
@@ -317,7 +327,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: Deprecated
+          description: Deprecated KAS grants for the attribute. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -562,7 +572,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -570,6 +580,65 @@ components:
           title: kas_keys
           description: Keys for the namespace
       title: Namespace
+      additionalProperties: false
+    policy.Obligation:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        namespace:
+          title: namespace
+          $ref: '#/components/schemas/policy.Namespace'
+        name:
+          type: string
+          title: name
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/policy.ObligationValue'
+          title: values
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: Obligation
+      additionalProperties: false
+    policy.ObligationTrigger:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        obligationValue:
+          title: obligation_value
+          $ref: '#/components/schemas/policy.ObligationValue'
+        action:
+          title: action
+          $ref: '#/components/schemas/policy.Action'
+        attributeValue:
+          title: attribute_value
+          $ref: '#/components/schemas/policy.Value'
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: ObligationTrigger
+      additionalProperties: false
+    policy.ObligationValue:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        obligation:
+          title: obligation
+          $ref: '#/components/schemas/policy.Obligation'
+        value:
+          type: string
+          title: value
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: ObligationValue
       additionalProperties: false
     policy.PrivateKeyCtx:
       type: object
@@ -908,9 +977,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: |-
-            Deprecated
-             list of key access servers
+          description: Deprecated KAS grants for the value. Use kas_keys instead.
         fqn:
           type: string
           title: fqn

--- a/specs/policy/obligations/obligations.openapi.yaml
+++ b/specs/policy/obligations/obligations.openapi.yaml
@@ -1,17 +1,13 @@
 openapi: 3.1.0
 info:
-  title: policy.attributes
+  title: policy.obligations
 paths:
-  /policy.attributes.AttributesService/ListAttributes:
+  /policy.obligations.Service/ListObligations:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: ListAttributes
-      description: |-
-        --------------------------------------*
-         Attribute RPCs
-        ---------------------------------------
-      operationId: policy.attributes.AttributesService.ListAttributes
+        - policy.obligations.Service
+      summary: ListObligations
+      operationId: policy.obligations.Service.ListObligations
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -26,7 +22,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.ListAttributesRequest'
+              $ref: '#/components/schemas/policy.obligations.ListObligationsRequest'
         required: true
       responses:
         default:
@@ -40,13 +36,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.ListAttributesResponse'
-  /policy.attributes.AttributesService/ListAttributeValues:
+                $ref: '#/components/schemas/policy.obligations.ListObligationsResponse'
+  /policy.obligations.Service/GetObligation:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: ListAttributeValues
-      operationId: policy.attributes.AttributesService.ListAttributeValues
+        - policy.obligations.Service
+      summary: GetObligation
+      operationId: policy.obligations.Service.GetObligation
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -61,7 +57,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.ListAttributeValuesRequest'
+              $ref: '#/components/schemas/policy.obligations.GetObligationRequest'
         required: true
       responses:
         default:
@@ -75,13 +71,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.ListAttributeValuesResponse'
-  /policy.attributes.AttributesService/GetAttribute:
+                $ref: '#/components/schemas/policy.obligations.GetObligationResponse'
+  /policy.obligations.Service/GetObligationsByFQNs:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: GetAttribute
-      operationId: policy.attributes.AttributesService.GetAttribute
+        - policy.obligations.Service
+      summary: GetObligationsByFQNs
+      operationId: policy.obligations.Service.GetObligationsByFQNs
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -96,7 +92,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.GetAttributeRequest'
+              $ref: '#/components/schemas/policy.obligations.GetObligationsByFQNsRequest'
         required: true
       responses:
         default:
@@ -110,74 +106,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.GetAttributeResponse'
-  /attributes/*/fqn:
-    get:
-      tags:
-        - policy.attributes.AttributesService
-      summary: GetAttributeValuesByFqns
-      operationId: policy.attributes.AttributesService.GetAttributeValuesByFqns
-      parameters:
-        - name: fqns
-          in: query
-          description: |-
-            Required
-             Fully Qualified Names of attribute values (i.e. https://<namespace>/attr/<attribute_name>/value/<value_name>), normalized to lower case.
-          schema:
-            type: array
-            items:
-              type: string
-              maxItems: 250
-              minItems: 1
-            title: fqns
-            maxItems: 250
-            minItems: 1
-            description: |-
-              Required
-               Fully Qualified Names of attribute values (i.e. https://<namespace>/attr/<attribute_name>/value/<value_name>), normalized to lower case.
-        - name: withValue.withKeyAccessGrants
-          in: query
-          description: Deprecated
-          schema:
-            type: boolean
-            title: with_key_access_grants
-            description: Deprecated
-        - name: withValue.withSubjectMaps
-          in: query
-          schema:
-            type: boolean
-            title: with_subject_maps
-        - name: withValue.withResourceMaps
-          in: query
-          schema:
-            type: boolean
-            title: with_resource_maps
-        - name: withValue.withAttribute.withKeyAccessGrants
-          in: query
-          description: Deprecated
-          schema:
-            type: boolean
-            title: with_key_access_grants
-            description: Deprecated
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsResponse'
-  /policy.attributes.AttributesService/CreateAttribute:
+                $ref: '#/components/schemas/policy.obligations.GetObligationsByFQNsResponse'
+  /policy.obligations.Service/CreateObligation:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: CreateAttribute
-      operationId: policy.attributes.AttributesService.CreateAttribute
+        - policy.obligations.Service
+      summary: CreateObligation
+      operationId: policy.obligations.Service.CreateObligation
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -192,7 +127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.CreateAttributeRequest'
+              $ref: '#/components/schemas/policy.obligations.CreateObligationRequest'
         required: true
       responses:
         default:
@@ -206,13 +141,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.CreateAttributeResponse'
-  /policy.attributes.AttributesService/UpdateAttribute:
+                $ref: '#/components/schemas/policy.obligations.CreateObligationResponse'
+  /policy.obligations.Service/UpdateObligation:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: UpdateAttribute
-      operationId: policy.attributes.AttributesService.UpdateAttribute
+        - policy.obligations.Service
+      summary: UpdateObligation
+      operationId: policy.obligations.Service.UpdateObligation
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -227,7 +162,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.UpdateAttributeRequest'
+              $ref: '#/components/schemas/policy.obligations.UpdateObligationRequest'
         required: true
       responses:
         default:
@@ -241,13 +176,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.UpdateAttributeResponse'
-  /policy.attributes.AttributesService/DeactivateAttribute:
+                $ref: '#/components/schemas/policy.obligations.UpdateObligationResponse'
+  /policy.obligations.Service/DeleteObligation:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: DeactivateAttribute
-      operationId: policy.attributes.AttributesService.DeactivateAttribute
+        - policy.obligations.Service
+      summary: DeleteObligation
+      operationId: policy.obligations.Service.DeleteObligation
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -262,7 +197,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.DeactivateAttributeRequest'
+              $ref: '#/components/schemas/policy.obligations.DeleteObligationRequest'
         required: true
       responses:
         default:
@@ -276,17 +211,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.DeactivateAttributeResponse'
-  /policy.attributes.AttributesService/GetAttributeValue:
+                $ref: '#/components/schemas/policy.obligations.DeleteObligationResponse'
+  /policy.obligations.Service/GetObligationValue:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: GetAttributeValue
-      description: |-
-        --------------------------------------*
-         Value RPCs
-        ---------------------------------------
-      operationId: policy.attributes.AttributesService.GetAttributeValue
+        - policy.obligations.Service
+      summary: GetObligationValue
+      operationId: policy.obligations.Service.GetObligationValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -301,7 +232,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.GetAttributeValueRequest'
+              $ref: '#/components/schemas/policy.obligations.GetObligationValueRequest'
         required: true
       responses:
         default:
@@ -315,13 +246,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.GetAttributeValueResponse'
-  /policy.attributes.AttributesService/CreateAttributeValue:
+                $ref: '#/components/schemas/policy.obligations.GetObligationValueResponse'
+  /policy.obligations.Service/GetObligationValuesByFQNs:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: CreateAttributeValue
-      operationId: policy.attributes.AttributesService.CreateAttributeValue
+        - policy.obligations.Service
+      summary: GetObligationValuesByFQNs
+      operationId: policy.obligations.Service.GetObligationValuesByFQNs
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -336,7 +267,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.CreateAttributeValueRequest'
+              $ref: '#/components/schemas/policy.obligations.GetObligationValuesByFQNsRequest'
         required: true
       responses:
         default:
@@ -350,13 +281,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.CreateAttributeValueResponse'
-  /policy.attributes.AttributesService/UpdateAttributeValue:
+                $ref: '#/components/schemas/policy.obligations.GetObligationValuesByFQNsResponse'
+  /policy.obligations.Service/CreateObligationValue:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: UpdateAttributeValue
-      operationId: policy.attributes.AttributesService.UpdateAttributeValue
+        - policy.obligations.Service
+      summary: CreateObligationValue
+      operationId: policy.obligations.Service.CreateObligationValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -371,7 +302,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.UpdateAttributeValueRequest'
+              $ref: '#/components/schemas/policy.obligations.CreateObligationValueRequest'
         required: true
       responses:
         default:
@@ -385,13 +316,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.UpdateAttributeValueResponse'
-  /policy.attributes.AttributesService/DeactivateAttributeValue:
+                $ref: '#/components/schemas/policy.obligations.CreateObligationValueResponse'
+  /policy.obligations.Service/UpdateObligationValue:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: DeactivateAttributeValue
-      operationId: policy.attributes.AttributesService.DeactivateAttributeValue
+        - policy.obligations.Service
+      summary: UpdateObligationValue
+      operationId: policy.obligations.Service.UpdateObligationValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -406,7 +337,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.DeactivateAttributeValueRequest'
+              $ref: '#/components/schemas/policy.obligations.UpdateObligationValueRequest'
         required: true
       responses:
         default:
@@ -420,17 +351,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.DeactivateAttributeValueResponse'
-  /policy.attributes.AttributesService/AssignKeyAccessServerToAttribute:
+                $ref: '#/components/schemas/policy.obligations.UpdateObligationValueResponse'
+  /policy.obligations.Service/DeleteObligationValue:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: AssignKeyAccessServerToAttribute
-      description: |-
-        --------------------------------------*
-         Attribute <> Key Access Server RPCs
-        ---------------------------------------
-      operationId: policy.attributes.AttributesService.AssignKeyAccessServerToAttribute
+        - policy.obligations.Service
+      summary: DeleteObligationValue
+      operationId: policy.obligations.Service.DeleteObligationValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -445,7 +372,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToAttributeRequest'
+              $ref: '#/components/schemas/policy.obligations.DeleteObligationValueRequest'
         required: true
       responses:
         default:
@@ -459,14 +386,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToAttributeResponse'
-      deprecated: true
-  /policy.attributes.AttributesService/RemoveKeyAccessServerFromAttribute:
+                $ref: '#/components/schemas/policy.obligations.DeleteObligationValueResponse'
+  /policy.obligations.Service/AddObligationTrigger:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: RemoveKeyAccessServerFromAttribute
-      operationId: policy.attributes.AttributesService.RemoveKeyAccessServerFromAttribute
+        - policy.obligations.Service
+      summary: AddObligationTrigger
+      operationId: policy.obligations.Service.AddObligationTrigger
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -481,7 +407,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.RemoveKeyAccessServerFromAttributeRequest'
+              $ref: '#/components/schemas/policy.obligations.AddObligationTriggerRequest'
         required: true
       responses:
         default:
@@ -495,14 +421,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.RemoveKeyAccessServerFromAttributeResponse'
-      deprecated: true
-  /policy.attributes.AttributesService/AssignKeyAccessServerToValue:
+                $ref: '#/components/schemas/policy.obligations.AddObligationTriggerResponse'
+  /policy.obligations.Service/RemoveObligationTrigger:
     post:
       tags:
-        - policy.attributes.AttributesService
-      summary: AssignKeyAccessServerToValue
-      operationId: policy.attributes.AttributesService.AssignKeyAccessServerToValue
+        - policy.obligations.Service
+      summary: RemoveObligationTrigger
+      operationId: policy.obligations.Service.RemoveObligationTrigger
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -517,7 +442,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToValueRequest'
+              $ref: '#/components/schemas/policy.obligations.RemoveObligationTriggerRequest'
         required: true
       responses:
         default:
@@ -531,195 +456,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToValueResponse'
-      deprecated: true
-  /policy.attributes.AttributesService/RemoveKeyAccessServerFromValue:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: RemoveKeyAccessServerFromValue
-      operationId: policy.attributes.AttributesService.RemoveKeyAccessServerFromValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.RemoveKeyAccessServerFromValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.RemoveKeyAccessServerFromValueResponse'
-      deprecated: true
-  /policy.attributes.AttributesService/AssignPublicKeyToAttribute:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: AssignPublicKeyToAttribute
-      operationId: policy.attributes.AttributesService.AssignPublicKeyToAttribute
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToAttributeRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToAttributeResponse'
-  /policy.attributes.AttributesService/RemovePublicKeyFromAttribute:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: RemovePublicKeyFromAttribute
-      operationId: policy.attributes.AttributesService.RemovePublicKeyFromAttribute
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.RemovePublicKeyFromAttributeRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.RemovePublicKeyFromAttributeResponse'
-  /policy.attributes.AttributesService/AssignPublicKeyToValue:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: AssignPublicKeyToValue
-      operationId: policy.attributes.AttributesService.AssignPublicKeyToValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToValueResponse'
-  /policy.attributes.AttributesService/RemovePublicKeyFromValue:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: RemovePublicKeyFromValue
-      operationId: policy.attributes.AttributesService.RemovePublicKeyFromValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.RemovePublicKeyFromValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.RemovePublicKeyFromValueResponse'
+                $ref: '#/components/schemas/policy.obligations.RemoveObligationTriggerResponse'
 components:
   schemas:
-    common.ActiveStateEnum:
-      type: string
-      title: ActiveStateEnum
-      enum:
-        - ACTIVE_STATE_ENUM_UNSPECIFIED
-        - ACTIVE_STATE_ENUM_ACTIVE
-        - ACTIVE_STATE_ENUM_INACTIVE
-        - ACTIVE_STATE_ENUM_ANY
-      description: 'buflint ENUM_VALUE_PREFIX: to make sure that C++ scoping rules aren''t violated when users add new enum values to an enum in a given package'
     common.MetadataUpdateEnum:
       type: string
       title: MetadataUpdateEnum
@@ -1032,40 +771,6 @@ components:
       required:
         - rule
       additionalProperties: false
-    policy.AttributeValueSelector:
-      type: object
-      properties:
-        withKeyAccessGrants:
-          type: boolean
-          title: with_key_access_grants
-          description: Deprecated
-        withSubjectMaps:
-          type: boolean
-          title: with_subject_maps
-        withResourceMaps:
-          type: boolean
-          title: with_resource_maps
-        withAttribute:
-          title: with_attribute
-          $ref: '#/components/schemas/policy.AttributeValueSelector.AttributeSelector'
-      title: AttributeValueSelector
-      additionalProperties: false
-    policy.AttributeValueSelector.AttributeSelector:
-      type: object
-      properties:
-        withKeyAccessGrants:
-          type: boolean
-          title: with_key_access_grants
-          description: Deprecated
-        withNamespace:
-          title: with_namespace
-          $ref: '#/components/schemas/policy.AttributeValueSelector.AttributeSelector.NamespaceSelector'
-      title: AttributeSelector
-      additionalProperties: false
-    policy.AttributeValueSelector.AttributeSelector.NamespaceSelector:
-      type: object
-      title: NamespaceSelector
-      additionalProperties: false
     policy.Condition:
       type: object
       properties:
@@ -1239,6 +944,65 @@ components:
           title: kas_keys
           description: Keys for the namespace
       title: Namespace
+      additionalProperties: false
+    policy.Obligation:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        namespace:
+          title: namespace
+          $ref: '#/components/schemas/policy.Namespace'
+        name:
+          type: string
+          title: name
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/policy.ObligationValue'
+          title: values
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: Obligation
+      additionalProperties: false
+    policy.ObligationTrigger:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        obligationValue:
+          title: obligation_value
+          $ref: '#/components/schemas/policy.ObligationValue'
+        action:
+          title: action
+          $ref: '#/components/schemas/policy.Action'
+        attributeValue:
+          title: attribute_value
+          $ref: '#/components/schemas/policy.Value'
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: ObligationTrigger
+      additionalProperties: false
+    policy.ObligationValue:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        obligation:
+          title: obligation
+          $ref: '#/components/schemas/policy.Obligation'
+        value:
+          type: string
+          title: value
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: ObligationValue
       additionalProperties: false
     policy.PageRequest:
       type: object
@@ -1508,388 +1272,248 @@ components:
           $ref: '#/components/schemas/common.Metadata'
       title: Value
       additionalProperties: false
-    policy.attributes.AssignKeyAccessServerToAttributeRequest:
+    policy.obligations.AddObligationTriggerRequest:
       type: object
       properties:
-        attributeKeyAccessServer:
-          title: attribute_key_access_server
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.AttributeKeyAccessServer'
-      title: AssignKeyAccessServerToAttributeRequest
-      additionalProperties: false
-    policy.attributes.AssignKeyAccessServerToAttributeResponse:
-      type: object
-      properties:
-        attributeKeyAccessServer:
-          title: attribute_key_access_server
-          $ref: '#/components/schemas/policy.attributes.AttributeKeyAccessServer'
-      title: AssignKeyAccessServerToAttributeResponse
-      additionalProperties: false
-    policy.attributes.AssignKeyAccessServerToValueRequest:
-      type: object
-      properties:
-        valueKeyAccessServer:
-          title: value_key_access_server
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.ValueKeyAccessServer'
-      title: AssignKeyAccessServerToValueRequest
-      additionalProperties: false
-    policy.attributes.AssignKeyAccessServerToValueResponse:
-      type: object
-      properties:
-        valueKeyAccessServer:
-          title: value_key_access_server
-          $ref: '#/components/schemas/policy.attributes.ValueKeyAccessServer'
-      title: AssignKeyAccessServerToValueResponse
-      additionalProperties: false
-    policy.attributes.AssignPublicKeyToAttributeRequest:
-      type: object
-      properties:
-        attributeKey:
-          title: attribute_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.AttributeKey'
-      title: AssignPublicKeyToAttributeRequest
-      required:
-        - attributeKey
-      additionalProperties: false
-    policy.attributes.AssignPublicKeyToAttributeResponse:
-      type: object
-      properties:
-        attributeKey:
-          title: attribute_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.AttributeKey'
-      title: AssignPublicKeyToAttributeResponse
-      additionalProperties: false
-    policy.attributes.AssignPublicKeyToValueRequest:
-      type: object
-      properties:
-        valueKey:
-          title: value_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.ValueKey'
-      title: AssignPublicKeyToValueRequest
-      required:
-        - valueKey
-      additionalProperties: false
-    policy.attributes.AssignPublicKeyToValueResponse:
-      type: object
-      properties:
-        valueKey:
-          title: value_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.ValueKey'
-      title: AssignPublicKeyToValueResponse
-      additionalProperties: false
-    policy.attributes.AttributeKey:
-      type: object
-      properties:
-        attributeId:
+        obligationValueId:
           type: string
-          title: attribute_id
-          format: uuid
+          title: obligation_value_id
           description: Required
-        keyId:
+        actionId:
           type: string
-          title: key_id
-          format: uuid
-          description: Required
-      title: AttributeKey
-      required:
-        - attributeId
-        - keyId
-      additionalProperties: false
-    policy.attributes.AttributeKeyAccessServer:
-      type: object
-      properties:
-        attributeId:
+          title: action_id
+        attributeValueId:
           type: string
-          title: attribute_id
-          format: uuid
-          description: Required
-        keyAccessServerId:
-          type: string
-          title: key_access_server_id
-          format: uuid
-          description: Required
-      title: AttributeKeyAccessServer
-      additionalProperties: false
-      description: Deprecated
-    policy.attributes.CreateAttributeRequest:
-      type: object
-      properties:
-        namespaceId:
-          type: string
-          title: namespace_id
-          format: uuid
-          description: Required
-        name:
-          type: string
-          title: name
-          maxLength: 253
-          description: |+
-            Required
-            Attribute name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
-        rule:
-          title: rule
-          description: Required
-          $ref: '#/components/schemas/policy.AttributeRuleTypeEnum'
-        values:
-          type: array
-          items:
-            type: string
-            maxLength: 253
-            pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$
-            uniqueItems: true
-          title: values
-          uniqueItems: true
-          description: |-
-            Optional
-             Attribute values (when provided) must be alphanumeric strings, allowing hyphens and underscores but not as the first or last character.
-             The stored attribute value will be normalized to lower case.
-        metadata:
-          title: metadata
-          description: Optional
-          $ref: '#/components/schemas/common.MetadataMutable'
-      title: CreateAttributeRequest
-      required:
-        - name
-        - rule
-      additionalProperties: false
-    policy.attributes.CreateAttributeResponse:
-      type: object
-      properties:
-        attribute:
-          title: attribute
-          $ref: '#/components/schemas/policy.Attribute'
-      title: CreateAttributeResponse
-      additionalProperties: false
-    policy.attributes.CreateAttributeValueRequest:
-      type: object
-      properties:
-        attributeId:
-          type: string
-          title: attribute_id
-          format: uuid
-          description: Required
-        value:
-          type: string
-          title: value
-          maxLength: 253
-          description: |+
-            Required
-            Attribute value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute value will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+          title: attribute_value_id
         metadata:
           title: metadata
           description: |-
             Optional
              Common metadata
           $ref: '#/components/schemas/common.MetadataMutable'
-      title: CreateAttributeValueRequest
-      required:
-        - value
+      title: AddObligationTriggerRequest
       additionalProperties: false
-    policy.attributes.CreateAttributeValueResponse:
+      description: Triggers
+    policy.obligations.AddObligationTriggerResponse:
       type: object
       properties:
-        value:
-          title: value
-          $ref: '#/components/schemas/policy.Value'
-      title: CreateAttributeValueResponse
+        trigger:
+          title: trigger
+          $ref: '#/components/schemas/policy.ObligationTrigger'
+      title: AddObligationTriggerResponse
       additionalProperties: false
-    policy.attributes.DeactivateAttributeRequest:
-      type: object
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: Required
-      title: DeactivateAttributeRequest
-      additionalProperties: false
-    policy.attributes.DeactivateAttributeResponse:
-      type: object
-      properties:
-        attribute:
-          title: attribute
-          $ref: '#/components/schemas/policy.Attribute'
-      title: DeactivateAttributeResponse
-      additionalProperties: false
-    policy.attributes.DeactivateAttributeValueRequest:
-      type: object
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: Required
-      title: DeactivateAttributeValueRequest
-      additionalProperties: false
-    policy.attributes.DeactivateAttributeValueResponse:
-      type: object
-      properties:
-        value:
-          title: value
-          $ref: '#/components/schemas/policy.Value'
-      title: DeactivateAttributeValueResponse
-      additionalProperties: false
-    policy.attributes.GetAttributeRequest:
-      type: object
-      oneOf:
-        - properties:
-            attributeId:
-              type: string
-              title: attribute_id
-              format: uuid
-              description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
-          title: attribute_id
-          required:
-            - attributeId
-        - properties:
-            fqn:
-              type: string
-              title: fqn
-              minLength: 1
-              format: uri
-          title: fqn
-          required:
-            - fqn
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: Deprecated
-          deprecated: true
-      title: GetAttributeRequest
-      additionalProperties: false
-      description: |+
-        Either use deprecated 'id' field or one of 'attribute_id' or 'fqn', but not both:
-        ```
-        !(has(this.id) && (has(this.attribute_id) || has(this.fqn)))
-        ```
-
-        Either id or one of attribute_id or fqn must be set:
-        ```
-        has(this.id) || has(this.attribute_id) || has(this.fqn)
-        ```
-
-    policy.attributes.GetAttributeResponse:
-      type: object
-      properties:
-        attribute:
-          title: attribute
-          $ref: '#/components/schemas/policy.Attribute'
-      title: GetAttributeResponse
-      additionalProperties: false
-    policy.attributes.GetAttributeValueRequest:
+    policy.obligations.CreateObligationRequest:
       type: object
       oneOf:
         - properties:
             fqn:
               type: string
               title: fqn
-              minLength: 1
-              format: uri
           title: fqn
           required:
             - fqn
         - properties:
-            valueId:
+            id:
               type: string
-              title: value_id
-              format: uuid
-              description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
-          title: value_id
-          required:
-            - valueId
-      properties:
-        id:
-          type: string
+              title: id
           title: id
-          format: uuid
-          description: Deprecated
-          deprecated: true
-      title: GetAttributeValueRequest
+          required:
+            - id
+      properties:
+        name:
+          type: string
+          title: name
+        values:
+          type: array
+          items:
+            type: string
+          title: values
+          description: Optional
+        metadata:
+          title: metadata
+          description: |-
+            Optional
+             Common metadata
+          $ref: '#/components/schemas/common.MetadataMutable'
+      title: CreateObligationRequest
       additionalProperties: false
-      description: |+
-        /
-        / Value RPC messages
-        /
-        Either use deprecated 'id' field or one of 'value_id' or 'fqn', but not both:
-        ```
-        !(has(this.id) && (has(this.value_id) || has(this.fqn)))
-        ```
-
-        Either id or one of value_id or fqn must be set:
-        ```
-        has(this.id) || has(this.value_id) || has(this.fqn)
-        ```
-
-    policy.attributes.GetAttributeValueResponse:
+    policy.obligations.CreateObligationResponse:
+      type: object
+      properties:
+        obligation:
+          title: obligation
+          $ref: '#/components/schemas/policy.Obligation'
+      title: CreateObligationResponse
+      additionalProperties: false
+    policy.obligations.CreateObligationValueRequest:
+      type: object
+      oneOf:
+        - properties:
+            fqn:
+              type: string
+              title: fqn
+          title: fqn
+          required:
+            - fqn
+        - properties:
+            id:
+              type: string
+              title: id
+          title: id
+          required:
+            - id
+      properties:
+        value:
+          type: string
+          title: value
+        metadata:
+          title: metadata
+          description: |-
+            Optional
+             Common metadata
+          $ref: '#/components/schemas/common.MetadataMutable'
+      title: CreateObligationValueRequest
+      additionalProperties: false
+    policy.obligations.CreateObligationValueResponse:
       type: object
       properties:
         value:
           title: value
-          $ref: '#/components/schemas/policy.Value'
-      title: GetAttributeValueResponse
+          $ref: '#/components/schemas/policy.ObligationValue'
+      title: CreateObligationValueResponse
       additionalProperties: false
-    policy.attributes.GetAttributeValuesByFqnsRequest:
+    policy.obligations.DeleteObligationRequest:
+      type: object
+      oneOf:
+        - properties:
+            fqn:
+              type: string
+              title: fqn
+          title: fqn
+          required:
+            - fqn
+        - properties:
+            id:
+              type: string
+              title: id
+          title: id
+          required:
+            - id
+      title: DeleteObligationRequest
+      additionalProperties: false
+    policy.obligations.DeleteObligationResponse:
+      type: object
+      properties:
+        obligation:
+          title: obligation
+          $ref: '#/components/schemas/policy.Obligation'
+      title: DeleteObligationResponse
+      additionalProperties: false
+    policy.obligations.DeleteObligationValueRequest:
+      type: object
+      oneOf:
+        - properties:
+            fqn:
+              type: string
+              title: fqn
+          title: fqn
+          required:
+            - fqn
+        - properties:
+            id:
+              type: string
+              title: id
+          title: id
+          required:
+            - id
+      title: DeleteObligationValueRequest
+      additionalProperties: false
+    policy.obligations.DeleteObligationValueResponse:
+      type: object
+      properties:
+        value:
+          title: value
+          $ref: '#/components/schemas/policy.ObligationValue'
+      title: DeleteObligationValueResponse
+      additionalProperties: false
+    policy.obligations.GetObligationRequest:
+      type: object
+      oneOf:
+        - properties:
+            fqn:
+              type: string
+              title: fqn
+          title: fqn
+          required:
+            - fqn
+        - properties:
+            id:
+              type: string
+              title: id
+          title: id
+          required:
+            - id
+      title: GetObligationRequest
+      additionalProperties: false
+      description: Definitions
+    policy.obligations.GetObligationResponse:
+      type: object
+      properties:
+        obligation:
+          title: obligation
+          $ref: '#/components/schemas/policy.Obligation'
+      title: GetObligationResponse
+      additionalProperties: false
+    policy.obligations.GetObligationValueRequest:
+      type: object
+      oneOf:
+        - properties:
+            fqn:
+              type: string
+              title: fqn
+          title: fqn
+          required:
+            - fqn
+        - properties:
+            id:
+              type: string
+              title: id
+          title: id
+          required:
+            - id
+      title: GetObligationValueRequest
+      additionalProperties: false
+      description: Values
+    policy.obligations.GetObligationValueResponse:
+      type: object
+      properties:
+        value:
+          title: value
+          $ref: '#/components/schemas/policy.ObligationValue'
+      title: GetObligationValueResponse
+      additionalProperties: false
+    policy.obligations.GetObligationValuesByFQNsRequest:
       type: object
       properties:
         fqns:
           type: array
           items:
             type: string
-            maxItems: 250
-            minItems: 1
           title: fqns
-          maxItems: 250
-          minItems: 1
-          description: |-
-            Required
-             Fully Qualified Names of attribute values (i.e. https://<namespace>/attr/<attribute_name>/value/<value_name>), normalized to lower case.
-        withValue:
-          title: with_value
-          description: |-
-            Optional
-             This attribute value selector is not used currently, but left here for future use.
-          $ref: '#/components/schemas/policy.AttributeValueSelector'
-      title: GetAttributeValuesByFqnsRequest
+      title: GetObligationValuesByFQNsRequest
       additionalProperties: false
-    policy.attributes.GetAttributeValuesByFqnsResponse:
+    policy.obligations.GetObligationValuesByFQNsResponse:
       type: object
       properties:
-        fqnAttributeValues:
+        fqnValueMap:
           type: object
-          title: fqn_attribute_values
+          title: fqn_value_map
           additionalProperties:
             title: value
-            $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsResponse.AttributeAndValue'
-          description: map of FQNs to complete attributes and the one selected value
-      title: GetAttributeValuesByFqnsResponse
+            $ref: '#/components/schemas/policy.ObligationValue'
+      title: GetObligationValuesByFQNsResponse
       additionalProperties: false
-    policy.attributes.GetAttributeValuesByFqnsResponse.AttributeAndValue:
-      type: object
-      properties:
-        attribute:
-          title: attribute
-          $ref: '#/components/schemas/policy.Attribute'
-        value:
-          title: value
-          $ref: '#/components/schemas/policy.Value'
-      title: AttributeAndValue
-      additionalProperties: false
-    policy.attributes.GetAttributeValuesByFqnsResponse.FqnAttributeValuesEntry:
+    policy.obligations.GetObligationValuesByFQNsResponse.FqnValueMapEntry:
       type: object
       properties:
         key:
@@ -1897,234 +1521,147 @@ components:
           title: key
         value:
           title: value
-          $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsResponse.AttributeAndValue'
-      title: FqnAttributeValuesEntry
+          $ref: '#/components/schemas/policy.ObligationValue'
+      title: FqnValueMapEntry
       additionalProperties: false
-    policy.attributes.ListAttributeValuesRequest:
+    policy.obligations.GetObligationsByFQNsRequest:
       type: object
       properties:
-        attributeId:
+        fqns:
+          type: array
+          items:
+            type: string
+          title: fqns
+      title: GetObligationsByFQNsRequest
+      additionalProperties: false
+    policy.obligations.GetObligationsByFQNsResponse:
+      type: object
+      properties:
+        fqnObligationMap:
+          type: object
+          title: fqn_obligation_map
+          additionalProperties:
+            title: value
+            $ref: '#/components/schemas/policy.Obligation'
+      title: GetObligationsByFQNsResponse
+      additionalProperties: false
+    policy.obligations.GetObligationsByFQNsResponse.FqnObligationMapEntry:
+      type: object
+      properties:
+        key:
           type: string
-          title: attribute_id
-          format: uuid
-          description: Required
-        state:
-          title: state
-          description: |-
-            Optional
-             ACTIVE by default when not specified
-          $ref: '#/components/schemas/common.ActiveStateEnum'
+          title: key
+        value:
+          title: value
+          $ref: '#/components/schemas/policy.Obligation'
+      title: FqnObligationMapEntry
+      additionalProperties: false
+    policy.obligations.ListObligationsRequest:
+      type: object
+      oneOf:
+        - properties:
+            fqn:
+              type: string
+              title: fqn
+          title: fqn
+          required:
+            - fqn
+        - properties:
+            id:
+              type: string
+              title: id
+          title: id
+          required:
+            - id
+      properties:
         pagination:
           title: pagination
           description: Optional
           $ref: '#/components/schemas/policy.PageRequest'
-      title: ListAttributeValuesRequest
+      title: ListObligationsRequest
       additionalProperties: false
-    policy.attributes.ListAttributeValuesResponse:
+    policy.obligations.ListObligationsResponse:
       type: object
       properties:
-        values:
+        obligations:
           type: array
           items:
-            $ref: '#/components/schemas/policy.Value'
-          title: values
+            $ref: '#/components/schemas/policy.Obligation'
+          title: obligations
         pagination:
           title: pagination
           $ref: '#/components/schemas/policy.PageResponse'
-      title: ListAttributeValuesResponse
+      title: ListObligationsResponse
       additionalProperties: false
-    policy.attributes.ListAttributesRequest:
-      type: object
-      properties:
-        state:
-          title: state
-          description: |-
-            Optional
-             ACTIVE by default when not specified
-          $ref: '#/components/schemas/common.ActiveStateEnum'
-        namespace:
-          type: string
-          title: namespace
-          description: |-
-            Optional
-             Namespace ID or name
-        pagination:
-          title: pagination
-          description: Optional
-          $ref: '#/components/schemas/policy.PageRequest'
-      title: ListAttributesRequest
-      additionalProperties: false
-    policy.attributes.ListAttributesResponse:
-      type: object
-      properties:
-        attributes:
-          type: array
-          items:
-            $ref: '#/components/schemas/policy.Attribute'
-          title: attributes
-        pagination:
-          title: pagination
-          $ref: '#/components/schemas/policy.PageResponse'
-      title: ListAttributesResponse
-      additionalProperties: false
-    policy.attributes.RemoveKeyAccessServerFromAttributeRequest:
-      type: object
-      properties:
-        attributeKeyAccessServer:
-          title: attribute_key_access_server
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.AttributeKeyAccessServer'
-      title: RemoveKeyAccessServerFromAttributeRequest
-      additionalProperties: false
-    policy.attributes.RemoveKeyAccessServerFromAttributeResponse:
-      type: object
-      properties:
-        attributeKeyAccessServer:
-          title: attribute_key_access_server
-          $ref: '#/components/schemas/policy.attributes.AttributeKeyAccessServer'
-      title: RemoveKeyAccessServerFromAttributeResponse
-      additionalProperties: false
-    policy.attributes.RemoveKeyAccessServerFromValueRequest:
-      type: object
-      properties:
-        valueKeyAccessServer:
-          title: value_key_access_server
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.ValueKeyAccessServer'
-      title: RemoveKeyAccessServerFromValueRequest
-      additionalProperties: false
-    policy.attributes.RemoveKeyAccessServerFromValueResponse:
-      type: object
-      properties:
-        valueKeyAccessServer:
-          title: value_key_access_server
-          $ref: '#/components/schemas/policy.attributes.ValueKeyAccessServer'
-      title: RemoveKeyAccessServerFromValueResponse
-      additionalProperties: false
-    policy.attributes.RemovePublicKeyFromAttributeRequest:
-      type: object
-      properties:
-        attributeKey:
-          title: attribute_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.AttributeKey'
-      title: RemovePublicKeyFromAttributeRequest
-      required:
-        - attributeKey
-      additionalProperties: false
-    policy.attributes.RemovePublicKeyFromAttributeResponse:
-      type: object
-      properties:
-        attributeKey:
-          title: attribute_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.AttributeKey'
-      title: RemovePublicKeyFromAttributeResponse
-      additionalProperties: false
-    policy.attributes.RemovePublicKeyFromValueRequest:
-      type: object
-      properties:
-        valueKey:
-          title: value_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.ValueKey'
-      title: RemovePublicKeyFromValueRequest
-      required:
-        - valueKey
-      additionalProperties: false
-    policy.attributes.RemovePublicKeyFromValueResponse:
-      type: object
-      properties:
-        valueKey:
-          title: value_key
-          description: Required
-          $ref: '#/components/schemas/policy.attributes.ValueKey'
-      title: RemovePublicKeyFromValueResponse
-      additionalProperties: false
-    policy.attributes.UpdateAttributeRequest:
+    policy.obligations.RemoveObligationTriggerRequest:
       type: object
       properties:
         id:
           type: string
           title: id
-          format: uuid
-          description: Required
-        metadata:
-          title: metadata
-          description: Optional
-          $ref: '#/components/schemas/common.MetadataMutable'
-        metadataUpdateBehavior:
-          title: metadata_update_behavior
-          $ref: '#/components/schemas/common.MetadataUpdateEnum'
-      title: UpdateAttributeRequest
+      title: RemoveObligationTriggerRequest
       additionalProperties: false
-    policy.attributes.UpdateAttributeResponse:
+    policy.obligations.RemoveObligationTriggerResponse:
       type: object
       properties:
-        attribute:
-          title: attribute
-          $ref: '#/components/schemas/policy.Attribute'
-      title: UpdateAttributeResponse
+        trigger:
+          title: trigger
+          $ref: '#/components/schemas/policy.ObligationTrigger'
+      title: RemoveObligationTriggerResponse
       additionalProperties: false
-    policy.attributes.UpdateAttributeValueRequest:
+    policy.obligations.UpdateObligationRequest:
       type: object
       properties:
         id:
           type: string
           title: id
-          format: uuid
           description: Required
+        name:
+          type: string
+          title: name
+          description: Optional
         metadata:
           title: metadata
-          description: |-
-            Optional
-             Common metadata
           $ref: '#/components/schemas/common.MetadataMutable'
         metadataUpdateBehavior:
           title: metadata_update_behavior
           $ref: '#/components/schemas/common.MetadataUpdateEnum'
-      title: UpdateAttributeValueRequest
+      title: UpdateObligationRequest
       additionalProperties: false
-    policy.attributes.UpdateAttributeValueResponse:
+    policy.obligations.UpdateObligationResponse:
+      type: object
+      properties:
+        obligation:
+          title: obligation
+          $ref: '#/components/schemas/policy.Obligation'
+      title: UpdateObligationResponse
+      additionalProperties: false
+    policy.obligations.UpdateObligationValueRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: Required
+        value:
+          type: string
+          title: value
+          description: Optional
+        metadata:
+          title: metadata
+          $ref: '#/components/schemas/common.MetadataMutable'
+        metadataUpdateBehavior:
+          title: metadata_update_behavior
+          $ref: '#/components/schemas/common.MetadataUpdateEnum'
+      title: UpdateObligationValueRequest
+      additionalProperties: false
+    policy.obligations.UpdateObligationValueResponse:
       type: object
       properties:
         value:
           title: value
-          $ref: '#/components/schemas/policy.Value'
-      title: UpdateAttributeValueResponse
-      additionalProperties: false
-    policy.attributes.ValueKey:
-      type: object
-      properties:
-        valueId:
-          type: string
-          title: value_id
-          format: uuid
-          description: Required
-        keyId:
-          type: string
-          title: key_id
-          format: uuid
-          description: Required (The id listed in the AsymmetricKeys object)
-      title: ValueKey
-      required:
-        - valueId
-        - keyId
-      additionalProperties: false
-    policy.attributes.ValueKeyAccessServer:
-      type: object
-      properties:
-        valueId:
-          type: string
-          title: value_id
-          format: uuid
-          description: Required
-        keyAccessServerId:
-          type: string
-          title: key_access_server_id
-          format: uuid
-          description: Required
-      title: ValueKeyAccessServer
+          $ref: '#/components/schemas/policy.ObligationValue'
+      title: UpdateObligationValueResponse
       additionalProperties: false
     connect-protocol-version:
       type: number
@@ -2185,8 +1722,8 @@ components:
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
-  - name: policy.attributes.AttributesService
+  - name: policy.obligations.Service
     description: |-
       /
-      / Attribute Service
+      / Obligation Service
       /

--- a/specs/policy/registeredresources/registered_resources.openapi.yaml
+++ b/specs/policy/registeredresources/registered_resources.openapi.yaml
@@ -519,8 +519,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -673,7 +679,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: Deprecated
+          description: Deprecated KAS grants for the attribute. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -860,7 +866,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -1168,9 +1174,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: |-
-            Deprecated
-             list of key access servers
+          description: Deprecated KAS grants for the value. Use kas_keys instead.
         fqn:
           type: string
           title: fqn

--- a/specs/policy/resourcemapping/resource_mapping.openapi.yaml
+++ b/specs/policy/resourcemapping/resource_mapping.openapi.yaml
@@ -519,8 +519,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -673,7 +679,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: Deprecated
+          description: Deprecated KAS grants for the attribute. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -860,7 +866,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -1107,9 +1113,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: |-
-            Deprecated
-             list of key access servers
+          description: Deprecated KAS grants for the value. Use kas_keys instead.
         fqn:
           type: string
           title: fqn

--- a/specs/policy/selectors.openapi.yaml
+++ b/specs/policy/selectors.openapi.yaml
@@ -10,6 +10,7 @@ components:
         withKeyAccessGrants:
           type: boolean
           title: with_key_access_grants
+          description: Deprecated
         withNamespace:
           title: with_namespace
           $ref: '#/components/schemas/policy.AttributeDefinitionSelector.NamespaceSelector'
@@ -28,6 +29,7 @@ components:
         withKeyAccessGrants:
           type: boolean
           title: with_key_access_grants
+          description: Deprecated
         withSubjectMaps:
           type: boolean
           title: with_subject_maps
@@ -50,6 +52,7 @@ components:
         withKeyAccessGrants:
           type: boolean
           title: with_key_access_grants
+          description: Deprecated
         withValues:
           title: with_values
           $ref: '#/components/schemas/policy.AttributeNamespaceSelector.AttributeSelector.ValueSelector'
@@ -61,6 +64,7 @@ components:
         withKeyAccessGrants:
           type: boolean
           title: with_key_access_grants
+          description: Deprecated
         withSubjectMaps:
           type: boolean
           title: with_subject_maps
@@ -75,6 +79,7 @@ components:
         withKeyAccessGrants:
           type: boolean
           title: with_key_access_grants
+          description: Deprecated
         withSubjectMaps:
           type: boolean
           title: with_subject_maps
@@ -92,6 +97,7 @@ components:
         withKeyAccessGrants:
           type: boolean
           title: with_key_access_grants
+          description: Deprecated
         withNamespace:
           title: with_namespace
           $ref: '#/components/schemas/policy.AttributeValueSelector.AttributeSelector.NamespaceSelector'

--- a/specs/policy/subjectmapping/subject_mapping.openapi.yaml
+++ b/specs/policy/subjectmapping/subject_mapping.openapi.yaml
@@ -555,8 +555,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -709,7 +715,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: Deprecated
+          description: Deprecated KAS grants for the attribute. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -896,7 +902,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -1168,9 +1174,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: |-
-            Deprecated
-             list of key access servers
+          description: Deprecated KAS grants for the value. Use kas_keys instead.
         fqn:
           type: string
           title: fqn

--- a/specs/policy/unsafe/unsafe.openapi.yaml
+++ b/specs/policy/unsafe/unsafe.openapi.yaml
@@ -413,6 +413,24 @@ components:
         - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
         - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
         - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+    policy.KeyMode:
+      type: string
+      title: KeyMode
+      enum:
+        - KEY_MODE_UNSPECIFIED
+        - KEY_MODE_CONFIG_ROOT_KEY
+        - KEY_MODE_PROVIDER_ROOT_KEY
+        - KEY_MODE_REMOTE
+        - KEY_MODE_PUBLIC_KEY_ONLY
+      description: Describes the management and operational mode of a cryptographic key.
+    policy.KeyStatus:
+      type: string
+      title: KeyStatus
+      enum:
+        - KEY_STATUS_UNSPECIFIED
+        - KEY_STATUS_ACTIVE
+        - KEY_STATUS_ROTATED
+      description: The status of the key
     policy.SourceType:
       type: string
       title: SourceType
@@ -470,8 +488,14 @@ components:
         Wrapper message for `bool`.
 
          The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+         Not recommended for use in new APIs, but still useful for legacy APIs and
+         has no plan to be removed.
     google.protobuf.Timestamp:
       type: string
+      examples:
+        - 1s
+        - 1.000340012s
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -596,6 +620,51 @@ components:
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.AsymmetricKey:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: Required
+        keyId:
+          type: string
+          title: key_id
+          description: Required
+        keyAlgorithm:
+          title: key_algorithm
+          description: Required
+          $ref: '#/components/schemas/policy.Algorithm'
+        keyStatus:
+          title: key_status
+          description: Required
+          $ref: '#/components/schemas/policy.KeyStatus'
+        keyMode:
+          title: key_mode
+          description: Required Specifies how the key is managed (local or remote)
+          $ref: '#/components/schemas/policy.KeyMode'
+        publicKeyCtx:
+          title: public_key_ctx
+          description: Required Specific structure based on key provider implementation
+          $ref: '#/components/schemas/policy.PublicKeyCtx'
+        privateKeyCtx:
+          title: private_key_ctx
+          description: Optional Specific structure based on key provider implementation
+          $ref: '#/components/schemas/policy.PrivateKeyCtx'
+        providerConfig:
+          title: provider_config
+          description: Optional Configuration for the key provider
+          $ref: '#/components/schemas/policy.KeyProviderConfig'
+        legacy:
+          type: boolean
+          title: legacy
+          description: Optional Indicates a key may be found in TDFs without key identifiers
+        metadata:
+          title: metadata
+          description: Common metadata fields
+          $ref: '#/components/schemas/common.Metadata'
+      title: AsymmetricKey
+      additionalProperties: false
     policy.Attribute:
       type: object
       properties:
@@ -624,7 +693,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: Deprecated
+          description: Deprecated KAS grants for the attribute. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -697,6 +766,20 @@ components:
         - booleanOperator
       additionalProperties: false
       description: A collection of Conditions evaluated by the boolean_operator provided
+    policy.KasKey:
+      type: object
+      properties:
+        kasId:
+          type: string
+          title: kas_id
+        key:
+          title: key
+          $ref: '#/components/schemas/policy.AsymmetricKey'
+        kasUri:
+          type: string
+          title: kas_uri
+      title: KasKey
+      additionalProperties: false
     policy.KasPublicKey:
       type: object
       properties:
@@ -740,31 +823,6 @@ components:
       description: |-
         Deprecated
          A list of known KAS public keys
-    policy.Key:
-      type: object
-      properties:
-        id:
-          type: string
-          title: id
-          description: the database record ID, not the key ID (`kid`)
-        isActive:
-          title: is_active
-          $ref: '#/components/schemas/google.protobuf.BoolValue'
-        wasMapped:
-          title: was_mapped
-          $ref: '#/components/schemas/google.protobuf.BoolValue'
-        publicKey:
-          title: public_key
-          $ref: '#/components/schemas/policy.KasPublicKey'
-        kas:
-          title: kas
-          $ref: '#/components/schemas/policy.KeyAccessServer'
-        metadata:
-          title: metadata
-          description: Common metadata
-          $ref: '#/components/schemas/common.Metadata'
-      title: Key
-      additionalProperties: false
     policy.KeyAccessServer:
       type: object
       properties:
@@ -808,6 +866,25 @@ components:
       title: KeyAccessServer
       additionalProperties: false
       description: Key Access Server Registry
+    policy.KeyProviderConfig:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
+        configJson:
+          type: string
+          title: config_json
+          format: byte
+        metadata:
+          title: metadata
+          description: Common metadata
+          $ref: '#/components/schemas/common.Metadata'
+      title: KeyProviderConfig
+      additionalProperties: false
     policy.Namespace:
       type: object
       properties:
@@ -836,7 +913,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: KAS grants for the namespace
+          description: Deprecated KAS grants for the namespace. Use kas_keys instead.
         kasKeys:
           type: array
           items:
@@ -844,6 +921,20 @@ components:
           title: kas_keys
           description: Keys for the namespace
       title: Namespace
+      additionalProperties: false
+    policy.PrivateKeyCtx:
+      type: object
+      properties:
+        keyId:
+          type: string
+          title: key_id
+          minLength: 1
+          description: Required Key ID for the symmetric key wrapping this key.
+        wrappedKey:
+          type: string
+          title: wrapped_key
+          description: Optional Base64 encoded wrapped key. Conditionally required if key_mode is LOCAL. Should not be present if key_mode is REMOTE.
+      title: PrivateKeyCtx
       additionalProperties: false
     policy.PublicKey:
       type: object
@@ -873,6 +964,16 @@ components:
       title: PublicKey
       additionalProperties: false
       description: Deprecated
+    policy.PublicKeyCtx:
+      type: object
+      properties:
+        pem:
+          type: string
+          title: pem
+          minLength: 1
+          description: Required Base64 encoded public key in PEM format
+      title: PublicKeyCtx
+      additionalProperties: false
     policy.ResourceMapping:
       type: object
       properties:
@@ -1041,9 +1142,7 @@ components:
           items:
             $ref: '#/components/schemas/policy.KeyAccessServer'
           title: grants
-          description: |-
-            Deprecated
-             list of key access servers
+          description: Deprecated KAS grants for the value. Use kas_keys instead.
         fqn:
           type: string
           title: fqn
@@ -1148,15 +1247,32 @@ components:
           description: |-
             Required
              UUID of the Key
+        kid:
+          type: string
+          title: kid
+          description: |-
+            Required
+             The key id assigned to this key (Ex: "key-1")
+        kasUri:
+          type: string
+          title: kas_uri
+          description: |-
+            Required
+             The kas uri for which this key belongs (Ex: "https://kas.example.com:8080")
       title: UnsafeDeleteKasKeyRequest
+      required:
+        - kid
+        - kasUri
       additionalProperties: false
-      description: WARNING!!
+      description: |-
+        WARNING!!
+         Deleting a key will make it so that ANY TDF that was encrypted with this key cannot be decrypted by the platform.
     policy.unsafe.UnsafeDeleteKasKeyResponse:
       type: object
       properties:
         key:
           title: key
-          $ref: '#/components/schemas/policy.Key'
+          $ref: '#/components/schemas/policy.KasKey'
       title: UnsafeDeleteKasKeyResponse
       additionalProperties: false
     policy.unsafe.UnsafeDeleteNamespaceRequest:

--- a/src/openapi/check-vendored-yaml.ts
+++ b/src/openapi/check-vendored-yaml.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { openApiSpecsArray } from '../preprocessing';
+import { openApiSpecsArray } from '../../preprocessing';
 
 function fileHash(filePath: string): string {
   if (!fs.existsSync(filePath)) return '';
@@ -35,7 +35,7 @@ async function main() {
   for (const spec of openApiSpecsArray) {
     if (!spec.url) continue; // Only process specs with a URL
     // Remove leading './' for specPath if present, and resolve relative to this script
-    const specPath = spec.specPath.replace(/^\.\//, '../');
+    const specPath = spec.specPath.replace(/^\.\//, '../../');
     const absPath = path.resolve(__dirname, specPath);
     const tmpPath = absPath + '.tmp';
     // Download to tmpPath

--- a/src/openapi/check-vendored-yaml.ts
+++ b/src/openapi/check-vendored-yaml.ts
@@ -1,7 +1,5 @@
 /*
-
 When making changes to this file, consider: https://virtru.atlassian.net/browse/DSPX-1577
-
 */
 import * as fs from 'fs';
 import * as crypto from 'crypto';

--- a/src/openapi/check-vendored-yaml.ts
+++ b/src/openapi/check-vendored-yaml.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import * as crypto from 'crypto';
 import { openApiSpecsArray } from './preprocessing';
 
@@ -34,9 +33,8 @@ async function main() {
   let hasDiff = false;
   for (const spec of openApiSpecsArray) {
     if (!spec.url) continue; // Only process specs with a URL
-    // Remove leading './' for specPath if present, and resolve relative to this script
-    const specPath = spec.specPath.replace(/^\.\//, '../../');
-    const absPath = path.resolve(__dirname, specPath);
+    // absPaths is the absolute path to the spec file
+    const absPath = spec.specPath;
     const tmpPath = absPath + '.tmp';
     // Download to tmpPath
     await downloadFile(spec.url, tmpPath);
@@ -46,6 +44,8 @@ async function main() {
     if (oldHash !== newHash) {
       hasDiff = true;
       console.error(`❌ Vendored file out of date: ${spec.specPath}\nPlease run 'npm run update-vendored-yaml' to update.`);
+    } else {
+      console.log(`✅ Vendored file is up to date: ${spec.specPath}`);
     }
     fs.unlinkSync(tmpPath);
   }

--- a/src/openapi/check-vendored-yaml.ts
+++ b/src/openapi/check-vendored-yaml.ts
@@ -1,3 +1,8 @@
+/*
+
+When making changes to this file, consider: https://virtru.atlassian.net/browse/DSPX-1577
+
+*/
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import { openApiSpecsArray } from './preprocessing';

--- a/src/openapi/check-vendored-yaml.ts
+++ b/src/openapi/check-vendored-yaml.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { openApiSpecsArray } from '../../preprocessing';
+import { openApiSpecsArray } from './preprocessing';
 
 function fileHash(filePath: string): string {
   if (!fs.existsSync(filePath)) return '';

--- a/src/openapi/preprocessing.ts
+++ b/src/openapi/preprocessing.ts
@@ -1,7 +1,5 @@
 /*
-
 When making changes to this file, consider: https://virtru.atlassian.net/browse/DSPX-1577
-
 */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -113,7 +111,126 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
             categoryLinkSource: "info",
         },
     },
-    // Add more entries here for other OpenAPI specs
+    {
+        id: "Policy Objects",
+        specPath: path.join(specsDir, 'policy/objects.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/objects.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Key Management",
+        specPath: path.join(specsDir, 'policy/keymanagement/key_management.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/keymanagement`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/keymanagement/key_management.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Resource Mapping",
+        specPath: path.join(specsDir, 'policy/resourcemapping/resource_mapping.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/resourcemapping`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/resourcemapping/resource_mapping.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Namespaces",
+        specPath: path.join(specsDir, 'policy/namespaces/namespaces.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/namespaces`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/namespaces/namespaces.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Attributes",
+        specPath: path.join(specsDir, 'policy/attributes/attributes.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/attributes`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/attributes/attributes.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Unsafe Service",
+        specPath: path.join(specsDir, 'policy/unsafe/unsafe.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/unsafe`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/unsafe/unsafe.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Actions",
+        specPath: path.join(specsDir, 'policy/actions/actions.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/actions`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/actions/actions.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Registered Resources",
+        specPath: path.join(specsDir, 'policy/registeredresources/registered_resources.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/registeredresources`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/registeredresources/registered_resources.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Subject Mapping",
+        specPath: path.join(specsDir, 'policy/subjectmapping/subject_mapping.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/subjectmapping`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/subjectmapping/subject_mapping.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy KAS Registry",
+        specPath: path.join(specsDir, 'policy/kasregistry/key_access_server_registry.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/kasregistry`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/kasregistry/key_access_server_registry.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Obligations",
+        specPath: path.join(specsDir, 'policy/obligations/obligations.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy/obligations`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/obligations/obligations.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    },
+    {
+        id: "Policy Selectors",
+        specPath: path.join(specsDir, 'policy/selectors.openapi.yaml'),
+        outputDir: `${OUTPUT_PREFIX}/policy`,
+        url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/selectors.openapi.yaml',
+        sidebarOptions: {
+            groupPathsBy: "tag",
+            categoryLinkSource: "info",
+        },
+    }
 ];
 
 // Convert array to object keyed by id, omitting 'url' for Docusaurus config

--- a/src/openapi/preprocessing.ts
+++ b/src/openapi/preprocessing.ts
@@ -3,6 +3,21 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 
+// Utility to find the repo root (directory containing package.json)
+function findRepoRoot(startDir = __dirname): string {
+  let dir = startDir;
+  while (!fs.existsSync(path.join(dir, 'package.json'))) {
+    const parent = path.dirname(dir);
+    if (parent === dir) throw new Error('Could not find package.json in parent directories');
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const specsDir = path.join(repoRoot, 'specs');
+const specsProcessedDir = path.join(repoRoot, 'specs-processed');
+
 // Boolean to control whether we add '[Preprocessed on' timestamp ']' to the description
 const ADD_TIMESTAMP_TO_DESCRIPTION = false;
 
@@ -34,7 +49,7 @@ interface ApiSpecDefinition {
 let openApiSpecsArray: ApiSpecDefinition[] = [
     {
         id: "Well-Known Configuration",
-        specPath: "./specs/wellknownconfiguration/wellknown_configuration.openapi.yaml",
+        specPath: path.join(specsDir, 'wellknownconfiguration/wellknown_configuration.openapi.yaml'),
         outputDir: `${OUTPUT_PREFIX}/wellknownconfiguration`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/wellknownconfiguration/wellknown_configuration.openapi.yaml',
         sidebarOptions: {
@@ -44,10 +59,9 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
     },
     {
         id: "V1 Authorization",
-        specPath: "./specs/authorization/authorization.openapi.yaml",
+        specPath: path.join(specsDir, 'authorization/authorization.openapi.yaml'),
         outputDir: `${OUTPUT_PREFIX}/authorization/v1`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/authorization/authorization.openapi.yaml',
-        // specPathModified is auto-generated if not specified
         sidebarOptions: {
             groupPathsBy: "tag",
             categoryLinkSource: "info",
@@ -55,11 +69,10 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
     },
     {
         id: "V2 Authorization",
-        specPath: "./specs/authorization/v2/authorization.openapi.yaml",
+        specPath: path.join(specsDir, 'authorization/v2/authorization.openapi.yaml'),
         outputDir: `${OUTPUT_PREFIX}/authorization/v2`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/authorization/v2/authorization.openapi.yaml',
-        // Example of custom modified path:
-        specPathModified: "./specs-processed/authorization/v2/authorization.openapi.yaml",
+        // specPathModified: path.join(specsProcessedDir, 'authorization/v2/authorization.openapi.yaml'),
         sidebarOptions: {
             groupPathsBy: "tag",
             categoryLinkSource: "info",
@@ -67,7 +80,7 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
     },
     {
         id: "V1 Entity Resolution",
-        specPath: "./specs/entityresolution/entity_resolution.openapi.yaml",
+        specPath: path.join(specsDir, 'entityresolution/entity_resolution.openapi.yaml'),
         outputDir: `${OUTPUT_PREFIX}/entityresolution/v1`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/entityresolution/entity_resolution.openapi.yaml',
         sidebarOptions: {
@@ -77,7 +90,7 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
     },
     {
         id: "V2 Entity Resolution",
-        specPath: "./specs/entityresolution/v2/entity_resolution.openapi.yaml",
+        specPath: path.join(specsDir, 'entityresolution/v2/entity_resolution.openapi.yaml'),
         outputDir: `${OUTPUT_PREFIX}/entityresolution/v2`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/entityresolution/v2/entity_resolution.openapi.yaml',
         sidebarOptions: {
@@ -87,7 +100,7 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
     },
     {
         id: "kas",
-        specPath: "./specs/kas/kas.openapi.yaml",
+        specPath: path.join(specsDir, 'kas/kas.openapi.yaml'),
         outputDir: `${OUTPUT_PREFIX}/kas`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/kas/kas.openapi.yaml',
         sidebarOptions: {

--- a/src/openapi/preprocessing.ts
+++ b/src/openapi/preprocessing.ts
@@ -117,8 +117,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/objects.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -127,8 +127,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/keymanagement`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/keymanagement/key_management.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -137,8 +137,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/resourcemapping`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/resourcemapping/resource_mapping.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -147,8 +147,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/namespaces`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/namespaces/namespaces.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -157,8 +157,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/attributes`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/attributes/attributes.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -167,8 +167,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/unsafe`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/unsafe/unsafe.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -177,8 +177,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/actions`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/actions/actions.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -187,8 +187,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/registeredresources`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/registeredresources/registered_resources.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -207,8 +207,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/kasregistry`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/kasregistry/key_access_server_registry.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -217,8 +217,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy/obligations`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/obligations/obligations.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     },
     {
@@ -227,8 +227,8 @@ let openApiSpecsArray: ApiSpecDefinition[] = [
         outputDir: `${OUTPUT_PREFIX}/policy`,
         url: 'https://raw.githubusercontent.com/opentdf/platform/refs/heads/main/docs/openapi/policy/selectors.openapi.yaml',
         sidebarOptions: {
-            groupPathsBy: "tag",
             categoryLinkSource: "info",
+            groupPathsBy: "tagGroup",
         },
     }
 ];

--- a/src/openapi/update-vendored-yaml.ts
+++ b/src/openapi/update-vendored-yaml.ts
@@ -1,3 +1,8 @@
+/*
+
+When making changes to this file, consider: https://virtru.atlassian.net/browse/DSPX-1577
+
+*/
 import * as fs from 'fs';
 import * as path from 'path';
 import { openApiSpecsArray } from './preprocessing';

--- a/src/openapi/update-vendored-yaml.ts
+++ b/src/openapi/update-vendored-yaml.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { openApiSpecsArray } from '../preprocessing';
+import { openApiSpecsArray } from '../../preprocessing';
 
 /**
  * Downloads the latest vendored OpenAPI YAML files from the upstream GitHub repository
@@ -32,7 +32,7 @@ async function updateVendoredYaml() {
     for (const spec of openApiSpecsArray) {
         if (!spec.url) continue; // Only process specs with a URL
         // Remove leading './' for specPath if present, and resolve relative to this script
-        const specPath = spec.specPath.replace(/^\.\//, '../');
+        const specPath = spec.specPath.replace(/^\.\//, '../../');
         const absPath = path.resolve(__dirname, specPath);
         fs.mkdirSync(path.dirname(absPath), { recursive: true });
         console.log(`⬇️  Downloading ${spec.url} → ${absPath}`);

--- a/src/openapi/update-vendored-yaml.ts
+++ b/src/openapi/update-vendored-yaml.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { openApiSpecsArray } from '../../preprocessing';
+import { openApiSpecsArray } from './preprocessing';
 
 /**
  * Downloads the latest vendored OpenAPI YAML files from the upstream GitHub repository

--- a/src/openapi/update-vendored-yaml.ts
+++ b/src/openapi/update-vendored-yaml.ts
@@ -1,7 +1,5 @@
 /*
-
 When making changes to this file, consider: https://virtru.atlassian.net/browse/DSPX-1577
-
 */
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/openapi/update-vendored-yaml.ts
+++ b/src/openapi/update-vendored-yaml.ts
@@ -31,9 +31,8 @@ async function updateVendoredYaml() {
 
     for (const spec of openApiSpecsArray) {
         if (!spec.url) continue; // Only process specs with a URL
-        // Remove leading './' for specPath if present, and resolve relative to this script
-        const specPath = spec.specPath.replace(/^\.\//, '../../');
-        const absPath = path.resolve(__dirname, specPath);
+        // absPaths is the absolute path to the spec file
+        const absPath = spec.specPath;
         fs.mkdirSync(path.dirname(absPath), { recursive: true });
         console.log(`⬇️  Downloading ${spec.url} → ${absPath}`);
         try {


### PR DESCRIPTION
Fixes a bug where policy endpoints are missing from OpenAPI clients.

Also, fixes a bug where `preprocessOpenApiSpecs` was run at ["import-time"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#:~:text=imported%20module%27s%20side%20effects%20are%20produced%20before%20the%20rest%20of%20the%20module%27s%20code%20starts%20running) of `preprocessing.ts` leading to unexpected state.