### PR TITLE
link to opentdf org page instead of docs page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -109,7 +109,7 @@ const config: Config = {
           label: "Docs",
         },
         {
-          href: "https://github.com/opentdf/docs",
+          href: "https://github.com/opentdf",
           label: "GitHub",
           position: "right",
         },


### PR DESCRIPTION
the old github link linked to this /docs repo. we should link to platform or org; i chose org. 