### PR TITLE
fix(docs): correct `opentdf` hostname

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -468,7 +468,7 @@ These self-signed certificates are only valid for local development. Never use s
 Creating a profile allows us to store the host we want to connect to and then to tie our credentials to it when we login.
 
 ```shell
-otdfctl profile create platform-otdf-local https://platform.otdf.local:8443
+otdfctl profile create platform-otdf-local https://platform.opentdf.local:8443
 ```
 
 ## Login to the Platform


### PR DESCRIPTION
### Fix

Set hostname used for OpenTDF consistent with other uses on this page. 

### Issue

Under the heading Create a Profile ( https://opentdf.io/getting-started#create-a-profile ), we reference **`platform.otdf.local`**.

I expected it to be **`platform.opentdf.local`** (the same name we talk about for **`openssl`** and **`/etc/hosts`** ).
