### PR TITLE
fix(docs): remove duplicate docker-compose file

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -34,7 +34,7 @@ The first step is to get the platform running locally. You can use the following
 Not for production use.
 :::
 
-<a href="/getting-started/docker-compose.yaml" download="docker-compose.yaml" style={{display: 'inline-block', padding: '8px 16px', backgroundColor: '#0066cc', color: 'white', textDecoration: 'none', borderRadius: '4px', marginBottom: '16px'}}>Download docker-compose.yaml</a>
+<a href="/quickstart/docker-compose.yaml" download="docker-compose.yaml" style={{display: 'inline-block', padding: '8px 16px', backgroundColor: '#0066cc', color: 'white', textDecoration: 'none', borderRadius: '4px', marginBottom: '16px'}}>Download docker-compose.yaml</a>
 
 <details>
 <summary>Docker Compose</summary>

--- a/static/quickstart/docker-compose.yaml
+++ b/static/quickstart/docker-compose.yaml
@@ -1,0 +1,1 @@
+../../docs/getting-started/docker-compose.yaml


### PR DESCRIPTION
Replace this outdated content with a (git) symlink to `../../docs/getting-started/docker-compose.yaml` .  This way, there's one-and-only-one **docker-compose.yaml** file for end-users.

In other words:
* `static/quickstart/docker-compose.yaml` is removed
* [docs/getting-started/docker-compose.yaml](https://github.com/opentdf/docs/blob/main/docs/getting-started/docker-compose.yaml) is still in-place