### PR TITLE
fix(docs): tidying "Getting started"

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -15,6 +15,13 @@ import CodeBlock from '@theme/CodeBlock';
   text-decoration: none;
   border-radius: 4px;
   margin-bottom: 16px;
+  transition: all 0.2s ease;
+}
+
+.download-button:hover {
+  background-color: #0052a3;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  color: white;
 }
 
 `}


### PR DESCRIPTION
* Extract CSS to a file-level `<style>` block
* Correct the `docker ...` copy commands, which have been broken for several days (before my recent improvements)