### PR TITLE
fix: light theme glow and button visibility

### DIFF
--- a/src/components/landing/DeveloperFirst.module.css
+++ b/src/components/landing/DeveloperFirst.module.css
@@ -286,7 +286,7 @@
 }
 
 :global(html[data-theme='light']) .btnSecondary {
-  border-color: #e2e8f0;
+  border-color: #cbd5e1;
   color: #0f172a;
 }
 

--- a/src/components/landing/FinalCTA.module.css
+++ b/src/components/landing/FinalCTA.module.css
@@ -84,8 +84,8 @@
 
 .btnGhost {
   background: transparent;
-  color: #6b7280;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--otdf-text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .btnGhost:hover {
@@ -144,7 +144,7 @@
 }
 
 :global(html[data-theme='light']) .btnSecondary {
-  border-color: #e2e8f0;
+  border-color: #cbd5e1;
   color: #0f172a;
 }
 
@@ -154,8 +154,8 @@
 }
 
 :global(html[data-theme='light']) .btnGhost {
-  border-color: #f1f5f9;
-  color: #64748b;
+  border-color: #cbd5e1;
+  color: #0f172a;
 }
 
 :global(html[data-theme='light']) .btnGhost:hover {

--- a/src/components/landing/Hero.module.css
+++ b/src/components/landing/Hero.module.css
@@ -311,7 +311,7 @@
 }
 
 :global(html[data-theme='light']) .btnSecondary {
-  border-color: #e2e8f0;
+  border-color: #cbd5e1;
   color: #0f172a;
 }
 
@@ -322,5 +322,5 @@
 
 :global(html[data-theme='light']) .codeWindow {
   border-color: #e2e8f0;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 0 20px rgba(8, 145, 178, 0.3), 0 0 60px rgba(8, 145, 178, 0.15), 0 0 100px rgba(8, 145, 178, 0.08);
 }

--- a/src/components/landing/Standards.module.css
+++ b/src/components/landing/Standards.module.css
@@ -149,8 +149,8 @@
 
 .btnGhost {
   background: transparent;
-  color: #6b7280;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--otdf-text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .btnGhost:hover {
@@ -241,7 +241,7 @@
 }
 
 :global(html[data-theme='light']) .btnSecondary {
-  border-color: #e2e8f0;
+  border-color: #cbd5e1;
   color: #0f172a;
 }
 
@@ -251,8 +251,8 @@
 }
 
 :global(html[data-theme='light']) .btnGhost {
-  border-color: #f1f5f9;
-  color: #64748b;
+  border-color: #cbd5e1;
+  color: #0f172a;
 }
 
 :global(html[data-theme='light']) .btnGhost:hover {

--- a/src/components/landing/Standards.tsx
+++ b/src/components/landing/Standards.tsx
@@ -102,7 +102,7 @@ export default function Standards() {
                 View Specification
               </a>
               <a href="/architecture" className={`${styles.btn} ${styles.btnGhost}`}>
-                Architecture<span className={styles.btnSuffix}> Overview</span>
+                Architecture
               </a>
             </div>
           </div>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -212,7 +212,7 @@ a[class*="embed_documentation_footer-"] {
 }
 
 .footer__sponsor-text {
-  font-size: 0.875rem;
+  font-size: 0.875rem !important;
   color: #6b7280;
   line-height: 1.6;
   margin: 0;

--- a/src/css/landing.css
+++ b/src/css/landing.css
@@ -124,7 +124,7 @@ html[data-theme='light'] .text-gradient {
 }
 
 html[data-theme='light'] .glow-cyan {
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 0 20px rgba(8, 145, 178, 0.3), 0 0 60px rgba(8, 145, 178, 0.15), 0 0 100px rgba(8, 145, 178, 0.08);
 }
 
 html[data-theme='light'] .sdk-card {


### PR DESCRIPTION
## Summary

- **Light theme code glow**: Added three-layer teal glow (`box-shadow`) to Hero code window and SDK cards, matching the dark theme's visual energy
- **Button border visibility**: Changed light-mode outline buttons from `#e2e8f0` to `#cbd5e1` across Hero, DeveloperFirst, Standards, and FinalCTA sections
- **Button label consistency**: Matched ghost button text color to secondary buttons in both light and dark themes
- **Footer sponsor text**: Added `!important` to enforce `0.875rem` font size matching link items
- **Standards CTA label**: Simplified "Architecture Overview" to "Architecture"

## Test plan

- [ ] Light theme: verify teal glow visible on Hero code window and SDK cards
- [ ] Light theme: verify all outline button borders are clearly visible
- [ ] Dark theme: verify ghost and secondary button labels are same white color
- [ ] Both themes: verify button hover states still work
- [ ] Footer: verify sponsor text matches link-item font size
- [ ] Responsive: spot-check all changes at mobile, tablet, and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)