### PR TITLE
fix: address review feedback on subject mapping guide

### DIFF
--- a/docs/guides/subject-mapping-guide.md
+++ b/docs/guides/subject-mapping-guide.md
@@ -77,25 +77,9 @@ sequenceDiagram
 
 For a detailed look at how these services fit together, see the [Architecture page](/architecture).
 
-## Subject Condition Sets: The Matching Engine
+## ERS Mode and What Selectors Target
 
-A **Subject Condition Set** is a logical expression that evaluates an entity representation to `true` or `false`.
-
-### Structure Hierarchy
-
-```
-SubjectConditionSet
-  └─ SubjectSets[]           (OR'd together - ANY set can match)
-      └─ ConditionGroups[]   (Combined by boolean operator)
-          └─ Conditions[]    (Combined by boolean operator)
-              ├─ SubjectExternalSelectorValue  (flattening-syntax selector to extract claim)
-              ├─ Operator                      (IN, NOT_IN, IN_CONTAINS)
-              └─ SubjectExternalValues         (Values to match)
-```
-
-### Selectors: String vs. Array Claims
-
-Selectors are evaluated against the **entity representation** produced by the Entity Resolution Service (ERS) — for example:
+Selectors are evaluated against the **entity representation** produced by the [Entity Resolution Service (ERS)](/components/entity_resolution) — for example:
 
 ```json
 {
@@ -110,21 +94,9 @@ Selectors are evaluated against the **entity representation** produced by the En
 }
 ```
 
-The selector syntax depends on whether the token claim is a **string** or an **array**:
+The platform supports two ERS modes, and the correct selector format depends on [which one is configured](https://github.com/opentdf/platform/blob/main/docs/Configuring.md?plain=1#L479).
 
-| Claim type | Example token | Selector |
-|------------|--------------|---------|
-| String | `"role": "admin"` | `.role` |
-| Array | `"groups": ["admin", "user"]` | `.groups[]` |
-| Nested string | `"realm_access": {"roles": [...]}` | `.realm_access.roles[]` |
-
-**Using `.groups` (without `[]`) on an array claim will silently match nothing.** The flattening library ([`lib/flattening/flatten.go`](https://github.com/opentdf/platform/blob/main/lib/flattening/flatten.go)) produces keys like `.groups[0]`, `.groups[1]`, and `.groups[]` for array elements — there is no `.groups` key. Use `otdfctl dev selectors generate` to see exactly what keys your token produces.
-
-### ERS Mode and What Selectors Target
-
-Selectors are evaluated against the **entity representation** produced by the [Entity Resolution Service (ERS)](/components/entity_resolution) — not directly against your JWT. The format of that representation depends on which ERS mode your platform is configured to use.
-
-**[Keycloak ERS](/components/entity_resolution) (default, `mode: keycloak`)**
+### Mode 1: [Keycloak ERS](/components/entity_resolution) (default, `mode: keycloak`)
 
 The ERS calls the Keycloak Admin API to fetch the full user object. Custom Keycloak user attributes are nested under `.attributes.<name>[]` and are **always an array**, regardless of whether the Keycloak attribute is configured as multi-valued:
 
@@ -139,7 +111,7 @@ A selector like `.department` will **never** match a custom Keycloak user attrib
 This is a frequent source of confusion because the JWT claim name and the entity representation key are different.
 :::
 
-**Claims ERS (`mode: claims`)**
+### Mode 2: Claims ERS (`mode: claims`)
 
 The ERS passes JWT private claims through as-is, so selectors match JWT claim names directly. In this mode, the correct selector also depends on the **multi-valued** setting of your Keycloak User Attribute mapper:
 
@@ -157,6 +129,34 @@ services:
 ```
 
 Trade-off: claims mode can only access what is in the token — it cannot look up Keycloak groups, roles, or other data from the user store that is not included in the JWT.
+
+## Subject Condition Sets: The Matching Engine
+
+A [**Subject Condition Set**](/components/policy/subject_mappings#subject-condition-set) is a logical expression that evaluates an entity representation to `true` or `false`.
+
+### Structure Hierarchy
+
+```
+SubjectConditionSet
+  └─ SubjectSets[]           (OR'd together - ANY set can match)
+      └─ ConditionGroups[]   (Combined by boolean operator)
+          └─ Conditions[]    (Combined by boolean operator)
+              ├─ SubjectExternalSelectorValue  (flattening-syntax selector to extract claim)
+              ├─ Operator                      (IN, NOT_IN, IN_CONTAINS)
+              └─ SubjectExternalValues         (Values to match)
+```
+
+### Selectors: String vs. Array Claims
+
+The selector syntax depends on whether the token claim is a **string** or an **array**:
+
+| Claim type | Example token | Selector |
+|------------|--------------|---------|
+| String | `"role": "admin"` | `.role` |
+| Array | `"groups": ["admin", "user"]` | `.groups[]` |
+| Nested string | `"realm_access": {"roles": [...]}` | `.realm_access.roles[]` |
+
+**Using `.groups` (without `[]`) on an array claim will silently match nothing.** The flattening library ([`lib/flattening/flatten.go`](https://github.com/opentdf/platform/blob/main/lib/flattening/flatten.go)) produces keys like `.groups[0]`, `.groups[1]`, and `.groups[]` for array elements — there is no `.groups` key. Use `otdfctl dev selectors generate` to see exactly what keys your token produces.
 
 ### Operators Explained
 


### PR DESCRIPTION
## Summary

Addresses feedback from the Mar 4 design review, plus new ERS mode documentation motivated by community discussion [opentdf/platform#3115](https://github.com/orgs/opentdf/discussions/3115).

- **Fix system flow diagram**: The `GetDecision` call goes from KAS → Authorization Service (O Service) first, not directly to ERS. Auth then orchestrates the ERS handshake. Updated the high-level diagram, all detailed step diagrams, and section headings to reflect the correct call order (steps 3-6, 7-9, 10-11).
- **Fix NIST table**: ERS row now correctly says "Used by Authorization Service" instead of "Used by Key Access Server."
- **Remove Entity Types and Categories section**: Jake confirmed these are internal implementation details that aren't fully implemented. Simplified the `jwtentity-0`/`jwtentity-1` warning in Step 3-6 to keep the practical log info without the incomplete category references.
- **Reframe one-mapping-per-user as anti-pattern**: Instead of presenting exact-match-per-user and pattern-based as two equal options, the section now leads with a warning callout marking per-user mappings as a performance "foot gun." Adopts framing: _"entitle kinds of users, not individual users."_
- **Add ERS Mode and What Selectors Target section**: Documents that selectors are evaluated against the ERS entity representation, not the raw JWT, and that the correct format depends on ERS mode:
  - Keycloak ERS (default): custom user attributes are at `.attributes.<name>[]`, not `.<name>` — includes a warning callout for this common mistake
  - Claims ERS (`mode: claims`): JWT claims are passed through directly; the multi-valued mapper setting determines whether to use `.claim` (string) or `.claim[]` (array)
  - Links to integration tests in [opentdf/platform#3122](https://github.com/opentdf/platform/pull/3122) that verify this behavior

## Preview

https://opentdf-docs-preview-pr-229.surge.sh/guides/subject-mapping-guide

## Test plan

- [ ] Verify mermaid diagrams render correctly in preview
- [ ] Check that all step numbers in prose match the updated diagrams
- [ ] Confirm no dangling references to the removed Entity Types section
- [ ] Verify new ERS mode section renders correctly (tables, warning callout, yaml code block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)