### PR TITLE
chore(deps): update vendored OpenAPI specs

### DIFF
--- a/specs/policy/actions/actions.openapi.yaml
+++ b/specs/policy/actions/actions.openapi.yaml
@@ -932,6 +932,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -969,6 +976,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'

--- a/specs/policy/attributes/attributes.openapi.yaml
+++ b/specs/policy/attributes/attributes.openapi.yaml
@@ -1453,6 +1453,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -1490,6 +1497,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'

--- a/specs/policy/objects.openapi.yaml
+++ b/specs/policy/objects.openapi.yaml
@@ -897,6 +897,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -934,6 +941,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'

--- a/specs/policy/obligations/obligations.openapi.yaml
+++ b/specs/policy/obligations/obligations.openapi.yaml
@@ -1281,6 +1281,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -1318,6 +1325,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'

--- a/specs/policy/registeredresources/registered_resources.openapi.yaml
+++ b/specs/policy/registeredresources/registered_resources.openapi.yaml
@@ -1206,6 +1206,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -1243,6 +1250,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'

--- a/specs/policy/resourcemapping/resource_mapping.openapi.yaml
+++ b/specs/policy/resourcemapping/resource_mapping.openapi.yaml
@@ -1142,6 +1142,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -1179,6 +1186,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'

--- a/specs/policy/subjectmapping/subject_mapping.openapi.yaml
+++ b/specs/policy/subjectmapping/subject_mapping.openapi.yaml
@@ -1178,6 +1178,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -1215,6 +1222,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'
@@ -1320,6 +1334,15 @@ components:
         subjectConditionSet:
           title: subject_condition_set
           $ref: '#/components/schemas/policy.subjectmapping.SubjectConditionSetCreate'
+        namespaceId:
+          type: string
+          title: namespace_id
+          format: uuid
+        namespaceFqn:
+          type: string
+          title: namespace_fqn
+          minLength: 1
+          format: uri
       title: CreateSubjectConditionSetRequest
       required:
         - subjectConditionSet
@@ -1371,6 +1394,18 @@ components:
           title: new_subject_condition_set
           description: 'Create new SubjectConditionSet (NOTE: ignored if existing_subject_condition_set_id is provided)'
           $ref: '#/components/schemas/policy.subjectmapping.SubjectConditionSetCreate'
+        namespaceId:
+          type: string
+          title: namespace_id
+          format: uuid
+          description: |-
+            Optional
+             Namespace ID or FQN for the subject mapping
+        namespaceFqn:
+          type: string
+          title: namespace_fqn
+          minLength: 1
+          format: uri
         metadata:
           title: metadata
           description: Optional
@@ -1484,6 +1519,15 @@ components:
     policy.subjectmapping.ListSubjectConditionSetsRequest:
       type: object
       properties:
+        namespaceId:
+          type: string
+          title: namespace_id
+          format: uuid
+        namespaceFqn:
+          type: string
+          title: namespace_fqn
+          minLength: 1
+          format: uri
         pagination:
           title: pagination
           description: Optional
@@ -1506,6 +1550,15 @@ components:
     policy.subjectmapping.ListSubjectMappingsRequest:
       type: object
       properties:
+        namespaceId:
+          type: string
+          title: namespace_id
+          format: uuid
+        namespaceFqn:
+          type: string
+          title: namespace_fqn
+          minLength: 1
+          format: uri
         pagination:
           title: pagination
           description: Optional

--- a/specs/policy/unsafe/unsafe.openapi.yaml
+++ b/specs/policy/unsafe/unsafe.openapi.yaml
@@ -1174,6 +1174,13 @@ components:
         id:
           type: string
           title: id
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject condition set
+             possible this is empty in the case a subject condition set
+             has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         subjectSets:
           type: array
           items:
@@ -1211,6 +1218,13 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           description: The actions permitted by subjects in this mapping
+        namespace:
+          title: namespace
+          description: |-
+            the namespace containing this subject mapping
+             possible this is empty. If so that means
+             the Subject Mapping has not been migrated to a namespace.
+          $ref: '#/components/schemas/policy.Namespace'
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.Metadata'


### PR DESCRIPTION
Updates 8 stale vendored OpenAPI specs in `specs/policy/` to match upstream `opentdf/platform`.

Unblocks #243 (and any other open PRs hitting the vendored YAML check).