### PR TITLE
chore(docs): genericize OpenTDF product name in SDK docs

### DIFF
--- a/docs/sdks/authentication.mdx
+++ b/docs/sdks/authentication.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Authentication
 
-The OpenTDF SDKs authenticate with an [OIDC](https://openid.net/developers/how-connect-works/)-compatible identity provider (IdP) to obtain access tokens for the platform. The platform itself is a **resource server**, not an identity provider — you bring your own IdP (Keycloak is the reference implementation).
+The SDKs authenticate with an [OIDC](https://openid.net/developers/how-connect-works/)-compatible identity provider (IdP) to obtain access tokens for the platform. The platform itself is a **resource server**, not an identity provider — you bring your own IdP (Keycloak is the reference implementation).
 
 :::tip Not sure which method to use?
 The JavaScript SDK is designed for **browser applications**. If your app already has an access token, use [Access Token](#access-token). If your OIDC flow provides a refresh token, use [Refresh Token](#refresh-token) for automatic renewal. For backend scripts and testing, see [Client Credentials](#client-credentials). See the [Authentication Decision Guide](/guides/authentication-guide) for a full comparison.
@@ -106,7 +106,7 @@ const client = new OpenTDF({
 
 ## Token Exchange
 
-Use **token exchange** ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) when you already have a token from another identity system and need to exchange it for one the OpenTDF platform accepts. Common in federated identity and SAML environments.
+Use **token exchange** ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) when you already have a token from another identity system and need to exchange it for one the platform accepts. Common in federated identity and SAML environments.
 
 <Tabs>
 <TabItem value="go" label="Go">

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -9,7 +9,7 @@ import JsAuthNote from '../../code_samples/js_auth_note.mdx'
 
 # Authorization
 
-OpenTDF's authorization system answers two questions: *"What can this entity access?"* ([GetEntitlements](#getentitlements)) and *"Can this entity access this specific resource?"* ([GetDecision](#getdecision)). For batch checks, use [GetDecisionBulk](#getdecisionbulk).
+The authorization system answers two questions: *"What can this entity access?"* ([GetEntitlements](#getentitlements)) and *"Can this entity access this specific resource?"* ([GetDecision](#getdecision)). For batch checks, use [GetDecisionBulk](#getdecisionbulk).
 
 ## Setup
 

--- a/docs/sdks/policy.mdx
+++ b/docs/sdks/policy.mdx
@@ -16,7 +16,7 @@ import JsAuthNote from '../../code_samples/js_auth_note.mdx'
 
 # Managing Policy
 
-Policy in OpenTDF is the set of rules that govern who can access data and under what conditions. It is made up of **namespaces**, **attributes**, **subject mappings**, and **subject condition sets**. See [Policy](/components/policy) for the concept overview. The SDK provides CRUD access to these policy rules through remote gRPC calls powered by the [platform service client](/sdks/platform-client).
+Policy is the set of rules that govern who can access data and under what conditions. It is made up of **namespaces**, **attributes**, **subject mappings**, and **subject condition sets**. See [Policy](/components/policy) for the concept overview. The SDK provides CRUD access to these policy rules through remote gRPC calls powered by the [platform service client](/sdks/platform-client).
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Removes "OpenTDF" branding from prose in SDK pages (`authentication.mdx`, `authorization.mdx`, `policy.mdx`) so they read naturally when imported into the Data Security Platform docs
- Package names, import paths, code examples, and example data (e.g., `opentdf.io` namespaces) are unchanged
- Quickstart, index, and troubleshooting pages are excluded (not imported into DSP docs)

## Test plan
- [ ] Verify docs site builds cleanly (`npm run build`)
- [ ] Spot-check the three changed pages render correctly
- [ ] Confirm no broken links or missing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined SDK documentation wording for clarity and consistency across Authentication, Authorization, and Policy guides.
  * Simplified introductory phrases by removing redundant branding qualifiers.
  * Corrected phrasing in the Token Exchange explanation and other sentences for improved grammar and readability.
  * Documentation-only edits; no API, parameters, or code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->