### PR TITLE
fix(ci): sign bot commits and auto-update specs on build failure

### DIFF
--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -26,3 +26,8 @@ jobs:
         run: npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-vendored-specs:
+    needs: test-deploy
+    if: failure()
+    uses: ./.github/workflows/update-vendored-specs.yaml

--- a/.github/workflows/update-vendored-specs.yaml
+++ b/.github/workflows/update-vendored-specs.yaml
@@ -2,6 +2,7 @@ name: Update vendored OpenAPI specs
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: update-vendored-specs
@@ -26,7 +27,7 @@ jobs:
       - name: Set up git identity
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Fix unsigned commits from `github-actions[bot]` by adding the numeric user ID prefix (`41898282+`) to the committer email — this enables GitHub to verify the signature, unblocking merge on repos with branch protection requiring verified commits
- Add `workflow_run` trigger so the vendored spec update runs automatically whenever a Test deployment workflow fails (e.g., due to stale specs)

## Test plan
- [ ] Merge this PR, then re-run the "Update vendored OpenAPI specs" workflow — verify the resulting commit on PR #289 shows as "Verified"
- [ ] Trigger a test-deploy failure to confirm the update-vendored-specs workflow fires automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an upstream workflow trigger so the update workflow can run after a related workflow completes.
  * Restricted the update job to run only on manual invocation or when the upstream workflow finishes with failure.
  * Updated the automated commit identity used by the workflow for generated commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->