### PR TITLE
chore(docs): update Java/JS examples to use EntityIdentifier helpers

### DIFF
--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -226,7 +226,7 @@ await platformClient.v2.authorization.getEntitlements({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `EntityIdentifiers.forEmail(...)` (JS). |
+| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
 | `withComprehensiveHierarchy` | `bool` | No | When true, returns all entitled values for attributes with hierarchy rules, propagating down from the entitled value. |
 
 **Example**
@@ -417,7 +417,7 @@ await platformClient.v2.authorization.getDecision({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `EntityIdentifiers.forEmail(...)` (JS). |
+| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
 | `action` | `Action` | Yes | The action being performed (e.g., `decrypt`, `read`). |
 | `resource` | `Resource` | Yes | The resource being accessed, identified by attribute value FQNs. |
 

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -69,7 +69,8 @@ const platformClient = new PlatformClient({
 
 Every authorization call requires an `EntityIdentifier` — the entity (user, service, etc.) you're asking about. The entity can be identified by email, username, client ID, JWT token, claims, or registered resource FQN.
 
-**Go** — use the v2 helper functions:
+<Tabs>
+<TabItem value="go" label="Go">
 
 | Helper | Description |
 |--------|-------------|
@@ -88,7 +89,8 @@ req := &authorizationv2.GetDecisionRequest{
 }
 ```
 
-**Java** — use the `EntityIdentifiers` helper class:
+</TabItem>
+<TabItem value="java" label="Java">
 
 | Helper | Description |
 |--------|-------------|
@@ -124,7 +126,8 @@ EntityIdentifier.newBuilder()
 
 </details>
 
-**JavaScript** — use the named helper functions:
+</TabItem>
+<TabItem value="js" label="JavaScript">
 
 | Helper | Description |
 |--------|-------------|
@@ -168,6 +171,9 @@ const response = await platformClient.v2.authorization.getDecision({
 ```
 
 </details>
+
+</TabItem>
+</Tabs>
 
 **Supported entity types:**
 

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -131,17 +131,17 @@ EntityIdentifier.newBuilder()
 
 | Helper | Description |
 |--------|-------------|
-| `forEmail(email)` | Identify by email address |
-| `forClientId(clientId)` | Identify by client ID (service account / NPE) |
-| `forUserName(username)` | Identify by username |
-| `forToken(jwt)` | Resolve entity from a JWT token |
-| `withRequestToken()` | Derive entity from the request's Authorization header |
+| `EntityIdentifiers.forEmail(email)` | Identify by email address |
+| `EntityIdentifiers.forClientId(clientId)` | Identify by client ID (service account / NPE) |
+| `EntityIdentifiers.forUserName(username)` | Identify by username |
+| `EntityIdentifiers.forToken(jwt)` | Resolve entity from a JWT token |
+| `EntityIdentifiers.withRequestToken()` | Derive entity from the request's Authorization header |
 
 ```typescript
-import { forEmail } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 
 const response = await platformClient.v2.authorization.getDecision({
-  entityIdentifier: forEmail('alice@example.com'),
+  entityIdentifier: EntityIdentifiers.forEmail('alice@example.com'),
   // ...
 });
 ```
@@ -179,11 +179,11 @@ const response = await platformClient.v2.authorization.getDecision({
 
 | Type | Go | Java | JavaScript |
 |------|-----|------|------------|
-| Email | `ForEmail(email)` | `forEmail(email)` | `forEmail(email)` |
-| Client ID | `ForClientID(id)` | `forClientId(id)` | `forClientId(id)` |
-| Username | `ForUserName(name)` | `forUserName(name)` | `forUserName(name)` |
-| JWT Token | `ForToken(jwt)` | `forToken(jwt)` | `forToken(jwt)` |
-| Request Token | `WithRequestToken()` | — | `withRequestToken()` |
+| Email | `ForEmail(email)` | `EntityIdentifiers.forEmail(email)` | `EntityIdentifiers.forEmail(email)` |
+| Client ID | `ForClientID(id)` | `forClientId(id)` | `EntityIdentifiers.forClientId(id)` |
+| Username | `ForUserName(name)` | `forUserName(name)` | `EntityIdentifiers.forUserName(name)` |
+| JWT Token | `ForToken(jwt)` | `forToken(jwt)` | `EntityIdentifiers.forToken(jwt)` |
+| Request Token | `WithRequestToken()` | — | `EntityIdentifiers.withRequestToken()` |
 
 ---
 
@@ -221,7 +221,7 @@ await platformClient.v2.authorization.getEntitlements({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `forEmail(...)` (JS). |
+| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `EntityIdentifiers.forEmail(...)` (JS). |
 | `withComprehensiveHierarchy` | `bool` | No | When true, returns all entitled values for attributes with hierarchy rules, propagating down from the entitled value. |
 
 **Example**
@@ -345,10 +345,10 @@ for (EntityEntitlements entitlement : resp.getEntitlementsList()) {
 <TabItem value="js" label="JavaScript">
 
 ```typescript
-import { forEmail } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 
 const response = await platformClient.v2.authorization.getEntitlements({
-  entityIdentifier: forEmail('bob@OrgA.com'),
+  entityIdentifier: EntityIdentifiers.forEmail('bob@OrgA.com'),
 });
 
 for (const entitlement of response.entitlements) {
@@ -359,10 +359,10 @@ for (const entitlement of response.entitlements) {
 To expand hierarchy rules:
 
 ```typescript
-import { forEmail } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 
 const response = await platformClient.v2.authorization.getEntitlements({
-  entityIdentifier: forEmail('user@company.com'),
+  entityIdentifier: EntityIdentifiers.forEmail('user@company.com'),
   withComprehensiveHierarchy: true,
 });
 
@@ -412,7 +412,7 @@ await platformClient.v2.authorization.getDecision({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `forEmail(...)` (JS). |
+| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `EntityIdentifiers.forEmail(...)` (JS). |
 | `action` | `Action` | Yes | The action being performed (e.g., `decrypt`, `read`). |
 | `resource` | `Resource` | Yes | The resource being accessed, identified by attribute value FQNs. |
 
@@ -586,11 +586,11 @@ if (decision.getDecision() == Decision.DECISION_PERMIT) {
 <TabItem value="js" label="JavaScript">
 
 ```typescript
-import { forEmail } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 import { Decision } from '@opentdf/sdk/platform/authorization/v2/authorization_pb.js';
 
 const response = await platformClient.v2.authorization.getDecision({
-  entityIdentifier: forEmail('user@company.com'),
+  entityIdentifier: EntityIdentifiers.forEmail('user@company.com'),
   action: { name: 'decrypt' },
   resource: {
     resource: {
@@ -828,12 +828,12 @@ import GetDecisionsExample from '@site/code_samples/java/get-decisions.mdx';
 <TabItem value="js" label="JavaScript">
 
 ```typescript
-import { forEmail } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 
 const response = await platformClient.v2.authorization.getDecisionBulk({
   decisionRequests: [
     {
-      entityIdentifier: forEmail('user@company.com'),
+      entityIdentifier: EntityIdentifiers.forEmail('user@company.com'),
       action: { name: 'decrypt' },
       resources: [
         {

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -88,7 +88,26 @@ req := &authorizationv2.GetDecisionRequest{
 }
 ```
 
-**Java** — build the nested proto structure:
+**Java** — use the `EntityIdentifiers` helper class:
+
+| Helper | Description |
+|--------|-------------|
+| `EntityIdentifiers.forEmail(email)` | Identify by email address |
+| `EntityIdentifiers.forClientId(clientId)` | Identify by client ID (service account / NPE) |
+| `EntityIdentifiers.forUserName(username)` | Identify by username |
+| `EntityIdentifiers.forToken(jwt)` | Resolve entity from a JWT token |
+
+```java
+import io.opentdf.platform.sdk.EntityIdentifiers;
+
+GetDecisionRequest request = GetDecisionRequest.newBuilder()
+    .setEntityIdentifier(EntityIdentifiers.forEmail("alice@example.com"))
+    // ...
+    .build();
+```
+
+<details>
+<summary>Without helpers (manual proto construction)</summary>
 
 ```java
 EntityIdentifier.newBuilder()
@@ -103,7 +122,29 @@ EntityIdentifier.newBuilder()
     .build()
 ```
 
-**JavaScript** — use the `identifier` oneof:
+</details>
+
+**JavaScript** — use the named helper functions:
+
+| Helper | Description |
+|--------|-------------|
+| `forEmail(email)` | Identify by email address |
+| `forClientId(clientId)` | Identify by client ID (service account / NPE) |
+| `forUserName(username)` | Identify by username |
+| `forToken(jwt)` | Resolve entity from a JWT token |
+| `withRequestToken()` | Derive entity from the request's Authorization header |
+
+```typescript
+import { forEmail } from '@opentdf/sdk';
+
+const response = await platformClient.v2.authorization.getDecision({
+  entityIdentifier: forEmail('alice@example.com'),
+  // ...
+});
+```
+
+<details>
+<summary>Without helpers (manual object construction)</summary>
 
 ```typescript
 {
@@ -126,19 +167,17 @@ EntityIdentifier.newBuilder()
 }
 ```
 
+</details>
+
 **Supported entity types:**
 
-| Type | Go helper | Java setter | JS `case` |
-|------|-----------|-------------|-----------|
-| Email | `ForEmail(email)` | `.setEmailAddress(email)` | `'emailAddress'` |
-| Client ID | `ForClientID(id)` | `.setClientId(id)` | `'clientId'` |
-| Username | `ForUserName(name)` | `.setUserName(name)` | `'userName'` |
-| JWT Token | `ForToken(jwt)` | `.setToken(Token.newBuilder().setJwt(jwt))` | `'token'` |
-| Claims | — | `.setClaims(claims)` | `'claims'` |
-| Registered Resource | — | `.setRegisteredResourceValueFqn(fqn)` | `'registeredResourceValueFqn'` |
-
-- **Claims** are used by the Entity Resolution Service (ERS) for custom claim-based entity resolution.
-- **Registered Resource** identifies an entity by a [registered resource](/components/policy/registered_resources) value FQN stored in platform policy, where the resource acts as a single entity for authorization decisions.
+| Type | Go | Java | JavaScript |
+|------|-----|------|------------|
+| Email | `ForEmail(email)` | `forEmail(email)` | `forEmail(email)` |
+| Client ID | `ForClientID(id)` | `forClientId(id)` | `forClientId(id)` |
+| Username | `ForUserName(name)` | `forUserName(name)` | `forUserName(name)` |
+| JWT Token | `ForToken(jwt)` | `forToken(jwt)` | `forToken(jwt)` |
+| Request Token | `WithRequestToken()` | — | `withRequestToken()` |
 
 ---
 
@@ -176,7 +215,7 @@ await platformClient.v2.authorization.getEntitlements({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. In Go, use helpers like `authorizationv2.ForEmail("user@example.com")`. |
+| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `forEmail(...)` (JS). |
 | `withComprehensiveHierarchy` | `bool` | No | When true, returns all entitled values for attributes with hierarchy rules, propagating down from the entitled value. |
 
 **Example**
@@ -279,18 +318,10 @@ for _, dr := range decisionResponse.GetDecisionResponses() {
 <TabItem value="java" label="Java">
 
 ```java
+import io.opentdf.platform.sdk.EntityIdentifiers;
+
 GetEntitlementsRequest request = GetEntitlementsRequest.newBuilder()
-    .setEntityIdentifier(
-        EntityIdentifier.newBuilder()
-            .setEntityChain(
-                EntityChain.newBuilder()
-                    .addEntities(
-                        Entity.newBuilder()
-                            .setId("user-bob")
-                            .setEmailAddress("bob@OrgA.com")
-                    )
-            )
-    )
+    .setEntityIdentifier(EntityIdentifiers.forEmail("bob@OrgA.com"))
     .build();
 
 GetEntitlementsResponse resp = sdk.getServices()
@@ -308,23 +339,10 @@ for (EntityEntitlements entitlement : resp.getEntitlementsList()) {
 <TabItem value="js" label="JavaScript">
 
 ```typescript
+import { forEmail } from '@opentdf/sdk';
+
 const response = await platformClient.v2.authorization.getEntitlements({
-  entityIdentifier: {
-    identifier: {
-      case: 'entityChain',
-      value: {
-        entities: [
-          {
-            ephemeralId: 'user-bob',
-            entityType: {
-              case: 'emailAddress',
-              value: 'bob@OrgA.com',
-            },
-          },
-        ],
-      },
-    },
-  },
+  entityIdentifier: forEmail('bob@OrgA.com'),
 });
 
 for (const entitlement of response.entitlements) {
@@ -335,20 +353,10 @@ for (const entitlement of response.entitlements) {
 To expand hierarchy rules:
 
 ```typescript
+import { forEmail } from '@opentdf/sdk';
+
 const response = await platformClient.v2.authorization.getEntitlements({
-  entityIdentifier: {
-    identifier: {
-      case: 'entityChain',
-      value: {
-        entities: [
-          {
-            ephemeralId: 'user-123',
-            entityType: { case: 'emailAddress', value: 'user@company.com' },
-          },
-        ],
-      },
-    },
-  },
+  entityIdentifier: forEmail('user@company.com'),
   withComprehensiveHierarchy: true,
 });
 
@@ -398,7 +406,7 @@ await platformClient.v2.authorization.getDecision({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. In Go, use helpers like `authorizationv2.ForEmail(...)` or `authorizationv2.ForToken(jwt)`. |
+| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go), `EntityIdentifiers.forEmail(...)` (Java), or `forEmail(...)` (JS). |
 | `action` | `Action` | Yes | The action being performed (e.g., `decrypt`, `read`). |
 | `resource` | `Resource` | Yes | The resource being accessed, identified by attribute value FQNs. |
 
@@ -534,18 +542,10 @@ for _, dr := range decisionResponse.GetDecisionResponses() {
 <TabItem value="java" label="Java">
 
 ```java
+import io.opentdf.platform.sdk.EntityIdentifiers;
+
 GetDecisionRequest request = GetDecisionRequest.newBuilder()
-    .setEntityIdentifier(
-        EntityIdentifier.newBuilder()
-            .setEntityChain(
-                EntityChain.newBuilder()
-                    .addEntities(
-                        Entity.newBuilder()
-                            .setId("user-123")
-                            .setEmailAddress("user@company.com")
-                    )
-            )
-    )
+    .setEntityIdentifier(EntityIdentifiers.forEmail("user@company.com"))
     .setAction(
         Action.newBuilder()
             .setName("decrypt")
@@ -580,22 +580,11 @@ if (decision.getDecision() == Decision.DECISION_PERMIT) {
 <TabItem value="js" label="JavaScript">
 
 ```typescript
+import { forEmail } from '@opentdf/sdk';
 import { Decision } from '@opentdf/sdk/platform/authorization/v2/authorization_pb.js';
 
 const response = await platformClient.v2.authorization.getDecision({
-  entityIdentifier: {
-    identifier: {
-      case: 'entityChain',
-      value: {
-        entities: [
-          {
-            ephemeralId: 'user-123',
-            entityType: { case: 'emailAddress', value: 'user@company.com' },
-          },
-        ],
-      },
-    },
-  },
+  entityIdentifier: forEmail('user@company.com'),
   action: { name: 'decrypt' },
   resource: {
     resource: {
@@ -778,20 +767,12 @@ for _, dr := range decisionResponse.GetDecisionResponses() {
 <TabItem value="java" label="Java">
 
 ```java
+import io.opentdf.platform.sdk.EntityIdentifiers;
+
 GetDecisionBulkRequest request = GetDecisionBulkRequest.newBuilder()
     .addDecisionRequests(
         GetDecisionMultiResourceRequest.newBuilder()
-            .setEntityIdentifier(
-                EntityIdentifier.newBuilder()
-                    .setEntityChain(
-                        EntityChain.newBuilder()
-                            .addEntities(
-                                Entity.newBuilder()
-                                    .setId("user-123")
-                                    .setEmailAddress("user@company.com")
-                            )
-                    )
-            )
+            .setEntityIdentifier(EntityIdentifiers.forEmail("user@company.com"))
             .setAction(Action.newBuilder().setName("decrypt"))
             .addResources(
                 Resource.newBuilder()
@@ -841,22 +822,12 @@ import GetDecisionsExample from '@site/code_samples/java/get-decisions.mdx';
 <TabItem value="js" label="JavaScript">
 
 ```typescript
+import { forEmail } from '@opentdf/sdk';
+
 const response = await platformClient.v2.authorization.getDecisionBulk({
   decisionRequests: [
     {
-      entityIdentifier: {
-        identifier: {
-          case: 'entityChain',
-          value: {
-            entities: [
-              {
-                ephemeralId: 'user-123',
-                entityType: { case: 'emailAddress', value: 'user@company.com' },
-              },
-            ],
-          },
-        },
-      },
+      entityIdentifier: forEmail('user@company.com'),
       action: { name: 'decrypt' },
       resources: [
         {

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -180,10 +180,15 @@ const response = await platformClient.v2.authorization.getDecision({
 | Type | Go | Java | JavaScript |
 |------|-----|------|------------|
 | Email | `ForEmail(email)` | `EntityIdentifiers.forEmail(email)` | `EntityIdentifiers.forEmail(email)` |
-| Client ID | `ForClientID(id)` | `forClientId(id)` | `EntityIdentifiers.forClientId(id)` |
-| Username | `ForUserName(name)` | `forUserName(name)` | `EntityIdentifiers.forUserName(name)` |
-| JWT Token | `ForToken(jwt)` | `forToken(jwt)` | `EntityIdentifiers.forToken(jwt)` |
+| Client ID | `ForClientID(id)` | `EntityIdentifiers.forClientId(id)` | `EntityIdentifiers.forClientId(id)` |
+| Username | `ForUserName(name)` | `EntityIdentifiers.forUserName(name)` | `EntityIdentifiers.forUserName(name)` |
+| JWT Token | `ForToken(jwt)` | `EntityIdentifiers.forToken(jwt)` | `EntityIdentifiers.forToken(jwt)` |
 | Request Token | `WithRequestToken()` | — | `EntityIdentifiers.withRequestToken()` |
+| Claims | — | manual proto construction | manual object construction |
+| Registered Resource | — | manual proto construction | manual object construction |
+
+- **Claims** are used by the Entity Resolution Service (ERS) for custom claim-based entity resolution.
+- **Registered Resource** identifies an entity by a [registered resource](/components/policy/registered_resources) value FQN stored in platform policy, where the resource acts as a single entity for authorization decisions.
 
 ---
 

--- a/docs/sdks/discovery.mdx
+++ b/docs/sdks/discovery.mdx
@@ -605,6 +605,10 @@ EntityIdentifiers.forUserName('alice')       // By username
 EntityIdentifiers.forClientId('my-service')  // By client ID (NPE / service account)
 ```
 
+:::note
+The JavaScript SDK does not currently provide a `forUuid` helper. To use UUID-based entity identifiers, construct the `EntityIdentifier` manually using the protobuf message types from `@opentdf/sdk/platform`.
+:::
+
 </TabItem>
 </Tabs>
 

--- a/docs/sdks/discovery.mdx
+++ b/docs/sdks/discovery.mdx
@@ -582,25 +582,13 @@ Entity.newBuilder().setId("e1").setUuid("550e8400-e29b-41d4-a716-446655440000").
 <TabItem value="js" label="JavaScript">
 
 ```typescript
+import { forEmail } from '@opentdf/sdk';
 import { PlatformClient } from '@opentdf/sdk/platform';
 
 const platform = new PlatformClient({ ...auth, platformUrl });
 
 const resp = await platform.v2.authorization.getEntitlements({
-  entityIdentifier: {
-    identifier: {
-      case: 'entityChain',
-      value: {
-        ephemeralId: 'e1',
-        entities: [
-          {
-            ephemeralId: 'e1',
-            entityType: { case: 'emailAddress', value: 'alice@example.com' },
-          },
-        ],
-      },
-    },
-  },
+  entityIdentifier: forEmail('alice@example.com'),
 });
 
 if (resp.entitlements.length > 0) {
@@ -608,14 +596,13 @@ if (resp.entitlements.length > 0) {
 }
 ```
 
-Other supported entity types (placed inside the `entities` array):
+Other supported [entity identifier helpers](/sdks/authorization#entityidentifier):
 
 ```typescript
-// By username
-{ ephemeralId: 'e1', entityType: { case: 'userName', value: 'alice' } }
+import { forUserName, forClientId } from '@opentdf/sdk';
 
-// By client ID (NPE / service account)
-{ ephemeralId: 'e1', entityType: { case: 'clientId', value: 'my-service' } }
+forUserName('alice')       // By username
+forClientId('my-service')  // By client ID (NPE / service account)
 ```
 
 </TabItem>

--- a/docs/sdks/discovery.mdx
+++ b/docs/sdks/discovery.mdx
@@ -582,13 +582,13 @@ Entity.newBuilder().setId("e1").setUuid("550e8400-e29b-41d4-a716-446655440000").
 <TabItem value="js" label="JavaScript">
 
 ```typescript
-import { forEmail } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 import { PlatformClient } from '@opentdf/sdk/platform';
 
 const platform = new PlatformClient({ ...auth, platformUrl });
 
 const resp = await platform.v2.authorization.getEntitlements({
-  entityIdentifier: forEmail('alice@example.com'),
+  entityIdentifier: EntityIdentifiers.forEmail('alice@example.com'),
 });
 
 if (resp.entitlements.length > 0) {
@@ -599,10 +599,10 @@ if (resp.entitlements.length > 0) {
 Other supported [entity identifier helpers](/sdks/authorization#entityidentifier):
 
 ```typescript
-import { forUserName, forClientId } from '@opentdf/sdk';
+import { EntityIdentifiers } from '@opentdf/sdk';
 
-forUserName('alice')       // By username
-forClientId('my-service')  // By client ID (NPE / service account)
+EntityIdentifiers.forUserName('alice')       // By username
+EntityIdentifiers.forClientId('my-service')  // By client ID (NPE / service account)
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary
- Add `EntityIdentifiers` helper tables and examples for Java and JavaScript to the EntityIdentifier reference section (now in language tabs)
- Update all Java examples to use `EntityIdentifiers.forEmail(...)` instead of verbose `EntityIdentifier.newBuilder().setEntityChain(...)` construction
- Update all JavaScript examples to use `EntityIdentifiers.forEmail(...)` instead of verbose nested object literals
- Update discovery page JS example to use helpers
- Move verbose construction patterns to collapsible `<details>` blocks for reference

## Related
- opentdf/web-sdk#916 — namespaces JS helpers under `EntityIdentifiers` (deprecates opentdf/web-sdk#911)
- opentdf/java-sdk#346 — Java `EntityIdentifiers` convenience constructors
- opentdf/platform#3232 — Go `EntityIdentifier` helpers

## Test plan
- [x] Verify docs build (`npm run build`) passes
- [ ] Check surge preview for correct rendering of helper tables, code examples, and details blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Unified entity identification docs into language-specific tabs with examples for Go/Java/JavaScript
  * Replaced manual nested identifier examples with SDK helper-based examples across Java and JavaScript; simplified sample payloads for entitlements and decision requests
  * Added JavaScript support for request-token identifiers; clarified when manual construction (e.g., UUIDs) is still required
  * Linked discovery guide examples to the new helper-based guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->