### PR TITLE
chore(docs): add Resource constructor helpers and update examples

### DIFF
--- a/code_samples/authorization/get_decision.mdx
+++ b/code_samples/authorization/get_decision.mdx
@@ -34,19 +34,16 @@ func main() {
 
 	// Get Decision using v2 API
 	// Convenience constructors live in the authorization/v2 package:
-	// ForClientID, ForEmail, ForUserName, ForToken, WithRequestToken
+	// Entity: ForClientID, ForEmail, ForUserName, ForToken, WithRequestToken
+	// Resource: ForAttributeValues, ForRegisteredResourceValueFqn
 	decisionReq := &authorization.GetDecisionRequest{
 		EntityIdentifier: authorization.ForClientID("opentdf"),
 		Action: &policy.Action{
 			Name: "decrypt",
 		},
-		Resource: &authorization.Resource{
-			Resource: &authorization.Resource_AttributeValues_{
-				AttributeValues: &authorization.Resource_AttributeValues{
-					Fqns: []string{"https://opentdf.io/attr/role/value/developer"},
-				},
-			},
-		},
+		Resource: authorization.ForAttributeValues(
+			"https://opentdf.io/attr/role/value/developer",
+		),
 	}
 
 	decision, err := client.AuthorizationV2.GetDecision(context.Background(), decisionReq)
@@ -141,7 +138,6 @@ import io.opentdf.platform.sdk.*;
 import java.util.concurrent.ExecutionException;
 
 import io.opentdf.platform.authorization.*;
-import io.opentdf.platform.entity.*;
 import io.opentdf.platform.policy.*;
 
 public class GetDecision {
@@ -158,28 +154,13 @@ public class GetDecision {
     
         // Get Decision using v2 API
         GetDecisionRequest request = GetDecisionRequest.newBuilder()
-            .setEntityIdentifier(
-                EntityIdentifier.newBuilder()
-                    .setEntityChain(
-                        EntityChain.newBuilder()
-                            .addEntities(
-                                Entity.newBuilder()
-                                    .setId("entity-1")
-                                    .setClientId("opentdf")
-                            )
-                    )
-            )
+            .setEntityIdentifier(EntityIdentifiers.forClientId("opentdf"))
             .setAction(
                 Action.newBuilder()
                     .setName("decrypt")
             )
-            .setResource(
-                Resource.newBuilder()
-                    .setAttributeValues(
-                        Resource.AttributeValues.newBuilder()
-                            .addFqns("https://opentdf.io/attr/role/value/developer")
-                    )
-            )
+            .setResource(Resources.forAttributeValues(
+                "https://opentdf.io/attr/role/value/developer"))
             .build();
 
         GetDecisionResponse resp = sdk.getServices().authorization().getDecision(request).get();
@@ -202,6 +183,7 @@ public class GetDecision {
 import {
   Decision,
 } from "@opentdf/sdk/platform/authorization/v2/authorization_pb.js";
+import { EntityIdentifiers, Resources } from "@opentdf/sdk";
 import { platformConnect, PlatformClient } from "@opentdf/sdk/platform";
 
 async function main() {
@@ -223,33 +205,11 @@ async function main() {
   // Get Decision using v2 API
   try {
     const response = await platformClient.v2.authorization.getDecision({
-      entityIdentifier: {
-        identifier: {
-          case: "entityChain",
-          value: {
-            entities: [
-              {
-                ephemeralId: "entity-1",
-                entityType: {
-                  case: "clientId",
-                  value: "opentdf",
-                },
-              },
-            ],
-          },
-        },
-      },
-      action: {
-        name: "decrypt",
-      },
-      resource: {
-        resource: {
-          case: "attributeValues",
-          value: {
-            fqns: ["https://opentdf.io/attr/role/value/developer"],
-          },
-        },
-      },
+      entityIdentifier: EntityIdentifiers.forClientId("opentdf"),
+      action: { name: "decrypt" },
+      resource: Resources.forAttributeValues(
+        "https://opentdf.io/attr/role/value/developer",
+      ),
     });
 
     const decision = response.decision;

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -440,7 +440,7 @@ await platform.v2.authorization.getEntitlements({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
+| `entityIdentifier` | [`EntityIdentifier`](#entityidentifier) | Yes | The entity to query. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
 | `withComprehensiveHierarchy` | `bool` | No | When true, returns all entitled values for attributes with hierarchy rules, propagating down from the entitled value. |
 
 **Example**
@@ -631,9 +631,9 @@ await platform.v2.authorization.getDecision({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
+| `entityIdentifier` | [`EntityIdentifier`](#entityidentifier) | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
 | `action` | `Action` | Yes | The action being performed (e.g., `decrypt`, `read`). |
-| `resource` | `Resource` | Yes | The resource being accessed. Use [helpers](#resource) like `ForAttributeValues(...)` (Go) or `Resources.forAttributeValues(...)` (Java/JS). |
+| `resource` | [`Resource`](#resource) | Yes | The resource being accessed. Use [helpers](#resource) like `ForAttributeValues(...)` (Go) or `Resources.forAttributeValues(...)` (Java/JS). |
 
 **Example**
 
@@ -863,9 +863,9 @@ Each `GetDecisionMultiResourceRequest` contains:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. |
+| `entityIdentifier` | [`EntityIdentifier`](#entityidentifier) | Yes | The entity requesting access. |
 | `action` | `Action` | Yes | The action being performed. |
-| `resources` | `[]Resource` | Yes | Resources to evaluate, each with an `ephemeralId` for correlation. |
+| `resources` | [`[]Resource`](#resource) | Yes | Resources to evaluate, each with an `ephemeralId` for correlation. |
 
 **Example**
 

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -277,6 +277,8 @@ A `Resource` identifies the data being accessed in [GetDecision](#getdecision) a
 <Tabs>
 <TabItem value="go" label="Go">
 
+<SdkVersion language="go" version="0.17.0" source="opentdf" />
+
 | Helper | Description |
 |--------|-------------|
 | `authorizationv2.ForAttributeValues(fqns...)` | Resource from attribute value FQNs (e.g. those on a TDF) |
@@ -315,6 +317,8 @@ req := &authorizationv2.GetDecisionRequest{
 </TabItem>
 <TabItem value="java" label="Java">
 
+<SdkVersion language="java" version="0.14.0" source="opentdf" />
+
 | Helper | Description |
 |--------|-------------|
 | `Resources.forAttributeValues(String... fqns)` | Resource from attribute value FQNs (e.g. those on a TDF) |
@@ -347,6 +351,8 @@ Resource.newBuilder()
 
 </TabItem>
 <TabItem value="js" label="JavaScript">
+
+<SdkVersion language="js" version="0.15.0" source="opentdf" />
 
 | Helper | Description |
 |--------|-------------|

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -37,8 +37,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// All Go snippets below use `client` and `context.Background()`.
-	_, _ = client, context.Background()
+	// All Go snippets below use `client` and `ctx`.
+	ctx := context.Background()
 }
 ```
 

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -137,36 +137,6 @@ req := &authorizationv2.GetDecisionRequest{
 
 </details>
 
-<details>
-<summary>Without helpers (manual proto construction)</summary>
-
-```go
-import (
-    "github.com/opentdf/platform/protocol/go/entity"
-    authorizationv2 "github.com/opentdf/platform/protocol/go/authorization/v2"
-)
-
-req := &authorizationv2.GetDecisionRequest{
-    EntityIdentifier: &authorizationv2.EntityIdentifier{
-        Identifier: &authorizationv2.EntityIdentifier_EntityChain{
-            EntityChain: &entity.EntityChain{
-                Entities: []*entity.Entity{
-                    {
-                        EntityType: &entity.Entity_EmailAddress{EmailAddress: "alice@example.com"},
-                        // or &entity.Entity_ClientId{ClientId: "..."}
-                        // or &entity.Entity_UserName{UserName: "..."}
-                        Category: entity.Entity_CATEGORY_SUBJECT,
-                    },
-                },
-            },
-        },
-    },
-    // ...
-}
-```
-
-</details>
-
 </TabItem>
 <TabItem value="java" label="Java">
 
@@ -362,7 +332,7 @@ Resource.newBuilder()
 ```typescript
 import { Resources } from '@opentdf/sdk';
 
-const response = await platformClient.v2.authorization.getDecision({
+const response = await platform.v2.authorization.getDecision({
   resource: Resources.forAttributeValues(
     'https://example.com/attr/classification/value/confidential',
     'https://example.com/attr/department/value/finance',

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -137,6 +137,36 @@ req := &authorizationv2.GetDecisionRequest{
 
 </details>
 
+<details>
+<summary>Without helpers (manual proto construction)</summary>
+
+```go
+import (
+    "github.com/opentdf/platform/protocol/go/entity"
+    authorizationv2 "github.com/opentdf/platform/protocol/go/authorization/v2"
+)
+
+req := &authorizationv2.GetDecisionRequest{
+    EntityIdentifier: &authorizationv2.EntityIdentifier{
+        Identifier: &authorizationv2.EntityIdentifier_EntityChain{
+            EntityChain: &entity.EntityChain{
+                Entities: []*entity.Entity{
+                    {
+                        EntityType: &entity.Entity_EmailAddress{EmailAddress: "alice@example.com"},
+                        // or &entity.Entity_ClientId{ClientId: "..."}
+                        // or &entity.Entity_UserName{UserName: "..."}
+                        Category: entity.Entity_CATEGORY_SUBJECT,
+                    },
+                },
+            },
+        },
+    },
+    // ...
+}
+```
+
+</details>
+
 </TabItem>
 <TabItem value="java" label="Java">
 

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -317,8 +317,8 @@ req := &authorizationv2.GetDecisionRequest{
 
 | Helper | Description |
 |--------|-------------|
-| `Resources.forAttributeValues(fqns...)` | Resource from attribute value FQNs (e.g. those on a TDF) |
-| `Resources.forRegisteredResourceValueFqn(fqn)` | Resource from a registered resource value FQN in policy |
+| `Resources.forAttributeValues(String... fqns)` | Resource from attribute value FQNs (e.g. those on a TDF) |
+| `Resources.forRegisteredResourceValueFqn(String fqn)` | Resource from a registered resource value FQN in policy |
 
 ```java
 import io.opentdf.platform.sdk.Resources;
@@ -391,11 +391,11 @@ const response = await platformClient.v2.authorization.getDecision({
 
 | Variant | Go | Java | JavaScript |
 |---------|-----|------|------------|
-| Attribute values | `ForAttributeValues(fqns...)` | `Resources.forAttributeValues(fqns...)` | `Resources.forAttributeValues(...fqns)` |
-| Registered resource | `ForRegisteredResourceValueFqn(fqn)` | `Resources.forRegisteredResourceValueFqn(fqn)` | `Resources.forRegisteredResourceValueFqn(fqn)` |
+| Attribute values | `authorizationv2.ForAttributeValues(fqns...)` | `Resources.forAttributeValues(String... fqns)` | `Resources.forAttributeValues(...fqns)` |
+| Registered resource | `authorizationv2.ForRegisteredResourceValueFqn(fqn)` | `Resources.forRegisteredResourceValueFqn(fqn)` | `Resources.forRegisteredResourceValueFqn(fqn)` |
 
 :::note
-The helpers do not set `ephemeralId`. For [GetDecisionBulk](#getdecisionbulk) where you need to correlate requests with responses, set `ephemeralId` separately after construction or use manual construction.
+The helpers do not set `ephemeralId`. For [GetDecisionBulk](#getdecisionbulk) where you need to correlate requests with responses, set `ephemeralId` separately after construction (in Go, assign the field directly; in Java, use `.toBuilder().setEphemeralId(...).build()`) or use manual construction.
 :::
 
 ---

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -270,6 +270,134 @@ const response = await platform.v2.authorization.getDecision({
 - **Claims** are used by the Entity Resolution Service (ERS) for custom claim-based entity resolution.
 - **Registered Resource** identifies an entity by a [registered resource](/components/policy/registered_resources) value FQN stored in platform policy, where the resource acts as a single entity for authorization decisions.
 
+### Resource
+
+A `Resource` identifies the data being accessed in [GetDecision](#getdecision) and [GetDecisionBulk](#getdecisionbulk) calls. It can be specified as a set of attribute value FQNs (most common — e.g. the attributes on a TDF) or as a [registered resource](/components/policy/registered_resources) value FQN stored in platform policy.
+
+<Tabs>
+<TabItem value="go" label="Go">
+
+| Helper | Description |
+|--------|-------------|
+| `authorizationv2.ForAttributeValues(fqns...)` | Resource from attribute value FQNs (e.g. those on a TDF) |
+| `authorizationv2.ForRegisteredResourceValueFqn(fqn)` | Resource from a registered resource value FQN in policy |
+
+```go
+import authorizationv2 "github.com/opentdf/platform/protocol/go/authorization/v2"
+
+req := &authorizationv2.GetDecisionRequest{
+    Resource: authorizationv2.ForAttributeValues(
+        "https://example.com/attr/classification/value/confidential",
+        "https://example.com/attr/department/value/finance",
+    ),
+    // ...
+}
+```
+
+<details>
+<summary>Without helpers (manual proto construction)</summary>
+
+```go
+&authorizationv2.Resource{
+    Resource: &authorizationv2.Resource_AttributeValues_{
+        AttributeValues: &authorizationv2.Resource_AttributeValues{
+            Fqns: []string{
+                "https://example.com/attr/classification/value/confidential",
+                "https://example.com/attr/department/value/finance",
+            },
+        },
+    },
+}
+```
+
+</details>
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+| Helper | Description |
+|--------|-------------|
+| `Resources.forAttributeValues(fqns...)` | Resource from attribute value FQNs (e.g. those on a TDF) |
+| `Resources.forRegisteredResourceValueFqn(fqn)` | Resource from a registered resource value FQN in policy |
+
+```java
+import io.opentdf.platform.sdk.Resources;
+
+GetDecisionRequest request = GetDecisionRequest.newBuilder()
+    .setResource(Resources.forAttributeValues(
+        "https://example.com/attr/classification/value/confidential",
+        "https://example.com/attr/department/value/finance"))
+    // ...
+    .build();
+```
+
+<details>
+<summary>Without helpers (manual proto construction)</summary>
+
+```java
+Resource.newBuilder()
+    .setAttributeValues(
+        Resource.AttributeValues.newBuilder()
+            .addFqns("https://example.com/attr/classification/value/confidential")
+            .addFqns("https://example.com/attr/department/value/finance"))
+    .build()
+```
+
+</details>
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+| Helper | Description |
+|--------|-------------|
+| `Resources.forAttributeValues(...fqns)` | Resource from attribute value FQNs (e.g. those on a TDF) |
+| `Resources.forRegisteredResourceValueFqn(fqn)` | Resource from a registered resource value FQN in policy |
+
+```typescript
+import { Resources } from '@opentdf/sdk';
+
+const response = await platformClient.v2.authorization.getDecision({
+  resource: Resources.forAttributeValues(
+    'https://example.com/attr/classification/value/confidential',
+    'https://example.com/attr/department/value/finance',
+  ),
+  // ...
+});
+```
+
+<details>
+<summary>Without helpers (manual object construction)</summary>
+
+```typescript
+{
+  resource: {
+    case: 'attributeValues',
+    value: {
+      fqns: [
+        'https://example.com/attr/classification/value/confidential',
+        'https://example.com/attr/department/value/finance',
+      ],
+    },
+  },
+}
+```
+
+</details>
+
+</TabItem>
+</Tabs>
+
+**Resource variants:**
+
+| Variant | Go | Java | JavaScript |
+|---------|-----|------|------------|
+| Attribute values | `ForAttributeValues(fqns...)` | `Resources.forAttributeValues(fqns...)` | `Resources.forAttributeValues(...fqns)` |
+| Registered resource | `ForRegisteredResourceValueFqn(fqn)` | `Resources.forRegisteredResourceValueFqn(fqn)` | `Resources.forRegisteredResourceValueFqn(fqn)` |
+
+:::note
+The helpers do not set `ephemeralId`. For [GetDecisionBulk](#getdecisionbulk) where you need to correlate requests with responses, set `ephemeralId` separately after construction or use manual construction.
+:::
+
 ---
 
 ## GetEntitlements
@@ -499,7 +627,7 @@ await platform.v2.authorization.getDecision({ ... })
 |-----------|------|----------|-------------|
 | `entityIdentifier` | `EntityIdentifier` | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
 | `action` | `Action` | Yes | The action being performed (e.g., `decrypt`, `read`). |
-| `resource` | `Resource` | Yes | The resource being accessed, identified by attribute value FQNs. |
+| `resource` | `Resource` | Yes | The resource being accessed. Use [helpers](#resource) like `ForAttributeValues(...)` (Go) or `Resources.forAttributeValues(...)` (Java/JS). |
 
 **Example**
 
@@ -517,16 +645,10 @@ decisionReq := &authorizationv2.GetDecisionRequest{
     Action: &policy.Action{
         Name: "decrypt",
     },
-    Resource: &authorizationv2.Resource{
-        Resource: &authorizationv2.Resource_AttributeValues_{
-            AttributeValues: &authorizationv2.Resource_AttributeValues{
-                Fqns: []string{
-                    "https://company.com/attr/clearance/value/confidential",
-                    "https://company.com/attr/department/value/finance",
-                },
-            },
-        },
-    },
+    Resource: authorizationv2.ForAttributeValues(
+        "https://company.com/attr/clearance/value/confidential",
+        "https://company.com/attr/department/value/finance",
+    ),
 }
 
 decision, err := client.AuthorizationV2.GetDecision(
@@ -559,13 +681,9 @@ import (
 decisionReq := &authorizationv2.GetDecisionRequest{
     EntityIdentifier: authorizationv2.ForToken(jwtToken),
     Action: &policy.Action{Name: "decrypt"},
-    Resource: &authorizationv2.Resource{
-        Resource: &authorizationv2.Resource_AttributeValues_{
-            AttributeValues: &authorizationv2.Resource_AttributeValues{
-                Fqns: []string{"https://company.com/attr/clearance/value/public"},
-            },
-        },
-    },
+    Resource: authorizationv2.ForAttributeValues(
+        "https://company.com/attr/clearance/value/public",
+    ),
 }
 
 decision, err := client.AuthorizationV2.GetDecision(
@@ -634,6 +752,7 @@ for _, dr := range decisionResponse.GetDecisionResponses() {
 
 ```java
 import io.opentdf.platform.sdk.EntityIdentifiers;
+import io.opentdf.platform.sdk.Resources;
 
 GetDecisionRequest request = GetDecisionRequest.newBuilder()
     .setEntityIdentifier(EntityIdentifiers.forEmail("user@company.com"))
@@ -641,14 +760,9 @@ GetDecisionRequest request = GetDecisionRequest.newBuilder()
         Action.newBuilder()
             .setName("decrypt")
     )
-    .setResource(
-        Resource.newBuilder()
-            .setAttributeValues(
-                Resource.AttributeValues.newBuilder()
-                    .addFqns("https://company.com/attr/clearance/value/confidential")
-                    .addFqns("https://company.com/attr/department/value/finance")
-            )
-    )
+    .setResource(Resources.forAttributeValues(
+        "https://company.com/attr/clearance/value/confidential",
+        "https://company.com/attr/department/value/finance"))
     .build();
 
 GetDecisionResponse resp = sdk.getServices()
@@ -671,23 +785,16 @@ if (decision.getDecision() == Decision.DECISION_PERMIT) {
 <TabItem value="js" label="JavaScript">
 
 ```typescript
-import { EntityIdentifiers } from '@opentdf/sdk';
+import { EntityIdentifiers, Resources } from '@opentdf/sdk';
 import { Decision } from '@opentdf/sdk/platform/authorization/v2/authorization_pb.js';
 
 const response = await platform.v2.authorization.getDecision({
   entityIdentifier: EntityIdentifiers.forEmail('user@company.com'),
   action: { name: 'decrypt' },
-  resource: {
-    resource: {
-      case: 'attributeValues',
-      value: {
-        fqns: [
-          'https://company.com/attr/clearance/value/confidential',
-          'https://company.com/attr/department/value/finance',
-        ],
-      },
-    },
-  },
+  resource: Resources.forAttributeValues(
+    'https://company.com/attr/clearance/value/confidential',
+    'https://company.com/attr/department/value/finance',
+  ),
 });
 
 const decision = response.decision;
@@ -992,28 +1099,37 @@ Identifies the data being accessed. A resource can be specified in two ways:
 | `attributeValues.fqns` | `[]string` | Attribute value FQNs on the resource (1–20). Use this for TDF payloads or any resource identified by attribute values. |
 | `registeredResourceValueFqn` | `string` (URI) | A [registered resource](/components/policy/registered_resources) value FQN stored in platform policy. Alternative to `attributeValues`. |
 
+Use the [Resource helpers](#resource) for concise construction:
+
+<Tabs>
+<TabItem value="go" label="Go">
+
 ```go
-// Go
-&authorizationv2.Resource{
-    EphemeralId: "resource-1",
-    Resource: &authorizationv2.Resource_AttributeValues_{
-        AttributeValues: &authorizationv2.Resource_AttributeValues{
-            Fqns: []string{"https://example.com/attr/classification/value/secret"},
-        },
-    },
-}
+// With helpers
+authorizationv2.ForAttributeValues("https://example.com/attr/classification/value/secret")
+authorizationv2.ForRegisteredResourceValueFqn("https://example.com/registered/value/my-resource")
 ```
 
-```typescript
-// JavaScript
-{
-  ephemeralId: 'resource-1',
-  resource: {
-    case: 'attributeValues',
-    value: { fqns: ['https://example.com/attr/classification/value/secret'] },
-  },
-}
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// With helpers
+Resources.forAttributeValues("https://example.com/attr/classification/value/secret")
+Resources.forRegisteredResourceValueFqn("https://example.com/registered/value/my-resource")
 ```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```typescript
+// With helpers
+Resources.forAttributeValues('https://example.com/attr/classification/value/secret')
+Resources.forRegisteredResourceValueFqn('https://example.com/registered/value/my-resource')
+```
+
+</TabItem>
+</Tabs>
 
 ### EntityEntitlements
 

--- a/docs/sdks/discovery.mdx
+++ b/docs/sdks/discovery.mdx
@@ -39,8 +39,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// All Go snippets below use `client` and `context.Background()`.
-	_, _ = client, context.Background()
+	// All Go snippets below use `client` and `ctx`.
+	ctx := context.Background()
 }
 ```
 

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -25,7 +25,7 @@ This page covers the core TDF operations:
 - **[Decrypt Options](#decrypt-options)** — full option reference for `LoadTDF`
 - **[Assertions](#assertions)** — signed metadata: types, scopes, signing, and verification
 - **[Session Encryption](#session-encryption)** — provide your own RSA key for KAS response encryption
-- **[Type Reference](#type-reference)** — `KASInfo`, `PolicyObject`, `Manifest`, `AssertionConfig`
+- **[Type Reference](#type-reference)** — `TDFObject`, `KASInfo`, `PolicyObject`, `Manifest`, `AssertionConfig`
 - **[Experimental: Streaming Writer](#experimental-streaming-writer)** — segment-based API for large files and out-of-order assembly
 
 ---

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -280,7 +280,7 @@ See [Encrypt Options](#encrypt-options) for the full list of configuration optio
 <Tabs>
 <TabItem value="go" label="Go">
 
-`(*TDFObject, error)` — On success, a `TDFObject` with a `.Manifest()` method returning the [Manifest](#manifest-object) and a `.Size()` method returning the encrypted byte count. Returns a non-nil `error` on failure.
+[`(*TDFObject, error)`](#tdfobject) — On success, a `TDFObject` with a `.Manifest()` method returning the [Manifest](#manifest-object) and a `.Size()` method returning the encrypted byte count. Returns a non-nil `error` on failure.
 
 </TabItem>
 <TabItem value="java" label="Java">
@@ -1268,6 +1268,23 @@ See the [Encrypt Options](#encrypt-options) and [Decrypt Options](#decrypt-optio
 ## Type Reference
 
 The following types are returned by or passed to the methods above.
+
+### TDFObject
+
+**Go only.** Returned by [`CreateTDF`](#createtdf). Contains the manifest and size of the encrypted TDF.
+
+**Methods**
+
+| Method | Return type | Description |
+|--------|-------------|-------------|
+| `Manifest()` | [`Manifest`](#manifest-object) | The TDF manifest, including encryption info, key access objects, and assertions. |
+| `Size()` | `int64` | Total byte count of the encrypted TDF written to the output. |
+
+:::note
+Java's `CreateTDF` returns a [`Manifest`](#manifest-object) directly. JavaScript's returns a `DecoratedStream`.
+:::
+
+---
 
 ### KASInfo
 


### PR DESCRIPTION
## Summary

- Add `### Resource` section documenting helper functions for all 3 SDKs (`ForAttributeValues`, `ForRegisteredResourceValueFqn`)
- Add `<SdkVersion>` annotations with minimum SDK versions: Go v0.17.0, Java v0.14.0, JS v0.15.0
- Update GetDecision examples (Go, Java, JS) to use helpers instead of verbose proto construction
- Update Type Reference Resource section with tabbed helper examples
- Add note about `ephemeralId` not being set by helpers (relevant for GetDecisionBulk)

Based on #303 (SdkVersion component + EntityIdentifier annotations).

**Companion PRs (SDK implementations):**
- Go: opentdf/platform#3337
- Java: opentdf/java-sdk#354
- JavaScript: opentdf/web-sdk#921

## Test plan

- [ ] `npm run build` passes
- [ ] Visual review of rendered authorization page
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced authorization docs with a new Resource section describing attribute-value and registered-resource formats, plus language-specific helper APIs and “without helpers” manual examples.
  * Updated GetDecision/GetDecisionBulk/GetEntitlements parameter docs to link entity/resource types and note Resource helper usage.
  * Rewrote multi-language GetDecision samples (Go/Java/JavaScript) to use Resource/Entity helper constructors.
  * Added Go TDFObject type reference and minor Go example ctx initialization updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->