### PR TITLE
chore(docs): use shorthand enum names in subject mapping docs

### DIFF
--- a/code_samples/policy_code/create_attribute.mdx
+++ b/code_samples/policy_code/create_attribute.mdx
@@ -55,7 +55,7 @@ resp, err := client.Attributes.CreateAttribute(context.Background(),
 	&attributes.CreateAttributeRequest{
 		NamespaceId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 		Name:        "classification",
-		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+		Rule:        policy.RuleAnyOf,
 		Values:      []string{"public", "confidential", "secret"},
 	},
 )

--- a/code_samples/policy_code/create_attribute.mdx
+++ b/code_samples/policy_code/create_attribute.mdx
@@ -1,5 +1,6 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import SdkVersion from '@site/src/components/SdkVersion';
 
 <details id="create-attribute">
 <summary>Create an Attribute</summary>
@@ -45,6 +46,8 @@ await platform.v1.attributes.createAttribute({ ... })
 <Tabs>
 <TabItem value="go" label="Go">
 
+<SdkVersion language="go" version="NEXT" source="opentdf" />
+
 ```go
 import (
 	"github.com/opentdf/platform/protocol/go/policy"
@@ -69,6 +72,8 @@ log.Printf("Created attribute: %s (ID: %s)\n",
 </TabItem>
 <TabItem value="java" label="Java">
 
+<SdkVersion language="java" version="NEXT" source="opentdf" />
+
 import CreateAttributeExample from '@site/code_samples/java/create-attribute.mdx';
 
 <CreateAttributeExample />
@@ -76,8 +81,10 @@ import CreateAttributeExample from '@site/code_samples/java/create-attribute.mdx
 </TabItem>
 <TabItem value="js" label="JavaScript">
 
+<SdkVersion language="js" version="NEXT" source="opentdf" />
+
 ```typescript
-import { AttributeRuleTypeEnum } from '@opentdf/sdk/platform/policy/objects_pb.js';
+import { AttributeRuleTypeEnum } from '@opentdf/sdk';
 
 const resp = await platform.v1.attributes.createAttribute({
   namespaceId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',

--- a/code_samples/policy_code/create_attribute.mdx
+++ b/code_samples/policy_code/create_attribute.mdx
@@ -46,7 +46,7 @@ await platform.v1.attributes.createAttribute({ ... })
 <Tabs>
 <TabItem value="go" label="Go">
 
-<SdkVersion language="go" version="NEXT" source="opentdf" />
+<SdkVersion language="go" version="0.18.0" source="opentdf" />
 
 ```go
 import (
@@ -72,7 +72,7 @@ log.Printf("Created attribute: %s (ID: %s)\n",
 </TabItem>
 <TabItem value="java" label="Java">
 
-<SdkVersion language="java" version="NEXT" source="opentdf" />
+<SdkVersion language="java" version="0.15.0" source="opentdf" />
 
 import CreateAttributeExample from '@site/code_samples/java/create-attribute.mdx';
 
@@ -81,7 +81,7 @@ import CreateAttributeExample from '@site/code_samples/java/create-attribute.mdx
 </TabItem>
 <TabItem value="js" label="JavaScript">
 
-<SdkVersion language="js" version="NEXT" source="opentdf" />
+<SdkVersion language="js" version="0.17.0" source="opentdf" />
 
 ```typescript
 import { AttributeRuleTypeEnum } from '@opentdf/sdk';

--- a/code_samples/policy_code/create_subject_condition_set.mdx
+++ b/code_samples/policy_code/create_subject_condition_set.mdx
@@ -1,5 +1,6 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import SdkVersion from '@site/src/components/SdkVersion';
 
 <details id="create-subject-condition-set">
 <summary>Create a Subject Condition Set</summary>
@@ -42,6 +43,8 @@ await platform.v1.subjectMapping.createSubjectConditionSet({ ... })
 <Tabs>
 <TabItem value="go" label="Go">
 
+<SdkVersion language="go" version="NEXT" source="opentdf" />
+
 ```go
 import (
 	"github.com/opentdf/platform/protocol/go/policy"
@@ -83,6 +86,8 @@ log.Printf("Created Subject Condition Set with ID: %s\n", resp.GetSubjectConditi
 </TabItem>
 <TabItem value="java" label="Java">
 
+<SdkVersion language="java" version="NEXT" source="opentdf" />
+
 import CreateSubjectConditionSetExample from '@site/code_samples/java/create-subject-condition-set.mdx';
 
 <CreateSubjectConditionSetExample />
@@ -90,12 +95,14 @@ import CreateSubjectConditionSetExample from '@site/code_samples/java/create-sub
 </TabItem>
 <TabItem value="js" label="JavaScript">
 
+<SdkVersion language="js" version="NEXT" source="opentdf" />
+
 ```typescript
 import { create } from '@bufbuild/protobuf';
 import {
   ConditionBooleanTypeEnum,
   SubjectMappingOperatorEnum,
-} from '@opentdf/sdk/platform/policy/objects_pb.js';
+} from '@opentdf/sdk';
 import {
   CreateSubjectConditionSetRequestSchema,
 } from '@opentdf/sdk/platform/policy/subjectmapping/subject_mapping_pb.js';

--- a/code_samples/policy_code/create_subject_condition_set.mdx
+++ b/code_samples/policy_code/create_subject_condition_set.mdx
@@ -56,11 +56,11 @@ conditionset := &subjectmapping.CreateSubjectConditionSetRequest{
 			{
 				ConditionGroups: []*policy.ConditionGroup{
 					{
-						BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+						BooleanOperator: policy.BooleanAnd,
 						Conditions: []*policy.Condition{
 							{
 								SubjectExternalSelectorValue: ".clientId",
-								Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+								Operator:                     policy.OperatorIn,
 								SubjectExternalValues:        []string{"opentdf"},
 							},
 						},

--- a/code_samples/policy_code/create_subject_condition_set.mdx
+++ b/code_samples/policy_code/create_subject_condition_set.mdx
@@ -43,7 +43,7 @@ await platform.v1.subjectMapping.createSubjectConditionSet({ ... })
 <Tabs>
 <TabItem value="go" label="Go">
 
-<SdkVersion language="go" version="NEXT" source="opentdf" />
+<SdkVersion language="go" version="0.18.0" source="opentdf" />
 
 ```go
 import (
@@ -86,7 +86,7 @@ log.Printf("Created Subject Condition Set with ID: %s\n", resp.GetSubjectConditi
 </TabItem>
 <TabItem value="java" label="Java">
 
-<SdkVersion language="java" version="NEXT" source="opentdf" />
+<SdkVersion language="java" version="0.15.0" source="opentdf" />
 
 import CreateSubjectConditionSetExample from '@site/code_samples/java/create-subject-condition-set.mdx';
 
@@ -95,7 +95,7 @@ import CreateSubjectConditionSetExample from '@site/code_samples/java/create-sub
 </TabItem>
 <TabItem value="js" label="JavaScript">
 
-<SdkVersion language="js" version="NEXT" source="opentdf" />
+<SdkVersion language="js" version="0.17.0" source="opentdf" />
 
 ```typescript
 import { create } from '@bufbuild/protobuf';

--- a/docs/sdks/policy.mdx
+++ b/docs/sdks/policy.mdx
@@ -1666,16 +1666,17 @@ log.Printf("Updated SCS ID: %s\n", resp.GetSubjectConditionSet().GetId())
 ```java
 import io.opentdf.platform.policy.*;
 import io.opentdf.platform.policy.subjectmapping.UpdateSubjectConditionSetRequest;
+import static io.opentdf.platform.sdk.PolicyEnums.*;
 
 var condition = Condition.newBuilder()
     .setSubjectExternalSelectorValue(".clientId")
-    .setOperator(SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN)
+    .setOperator(OPERATOR_IN)
     .addSubjectExternalValues("my-service")
     .addSubjectExternalValues("my-other-service")
     .build();
 
 var conditionGroup = ConditionGroup.newBuilder()
-    .setBooleanOperator(ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_AND)
+    .setBooleanOperator(BOOLEAN_AND)
     .addConditions(condition)
     .build();
 
@@ -1698,7 +1699,10 @@ System.out.println("Updated SCS ID: " + resp.getSubjectConditionSet().getId());
 <TabItem value="js" label="JavaScript">
 
 ```typescript
-import { authTokenInterceptor, clientCredentialsTokenProvider } from '@opentdf/sdk';
+import {
+  ConditionBooleanTypeEnum,
+  SubjectMappingOperatorEnum,
+} from '@opentdf/sdk';
 
 const resp = await platform.v1.subjectMapping.updateSubjectConditionSet({
   id: 'a0b1c2d3-0000-0000-0000-000000000099',
@@ -1706,11 +1710,11 @@ const resp = await platform.v1.subjectMapping.updateSubjectConditionSet({
     {
       conditionGroups: [
         {
-          booleanOperator: 'CONDITION_BOOLEAN_TYPE_ENUM_AND',
+          booleanOperator: ConditionBooleanTypeEnum.AND,
           conditions: [
             {
               subjectExternalSelectorValue: '.clientId',
-              operator: 'SUBJECT_MAPPING_OPERATOR_ENUM_IN',
+              operator: SubjectMappingOperatorEnum.IN,
               subjectExternalValues: ['my-service', 'my-other-service'],
             },
           ],

--- a/docs/sdks/policy.mdx
+++ b/docs/sdks/policy.mdx
@@ -1639,11 +1639,11 @@ resp, err := client.SubjectMapping.UpdateSubjectConditionSet(context.Background(
 			{
 				ConditionGroups: []*policy.ConditionGroup{
 					{
-						BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+						BooleanOperator: policy.BooleanAnd,
 						Conditions: []*policy.Condition{
 							{
 								SubjectExternalSelectorValue: ".clientId",
-								Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+								Operator:                     policy.OperatorIn,
 								SubjectExternalValues:        []string{"my-service", "my-other-service"},
 							},
 						},

--- a/docs/sdks/quickstart/go.mdx
+++ b/docs/sdks/quickstart/go.mdx
@@ -249,7 +249,7 @@ if getAttrResp == nil {
 		&attributes.CreateAttributeRequest{
 			NamespaceId: nsResp.GetNamespace().GetId(),
 			Name:        "department",
-			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Rule:        policy.RuleAnyOf,
 		})
 	if err != nil {
 		log.Fatalf("Failed to create attribute: %v", err)
@@ -360,11 +360,11 @@ scsResp, err := client.SubjectMapping.CreateSubjectConditionSet(context.Backgrou
 				{
 					ConditionGroups: []*policy.ConditionGroup{
 						{
-							BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+							BooleanOperator: policy.BooleanAnd,
 							Conditions: []*policy.Condition{
 								{
 									SubjectExternalSelectorValue: ".clientId",
-									Operator: policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+									Operator: policy.OperatorIn,
 									SubjectExternalValues:        []string{"opentdf"},
 								},
 							},
@@ -514,7 +514,7 @@ func main() {
 		&attributes.CreateAttributeRequest{
 			NamespaceId: nsResp.GetNamespace().GetId(),
 			Name:        "department",
-			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Rule:        policy.RuleAnyOf,
 			Values:      []string{"marketing"},
 		})
 	if err != nil {
@@ -583,11 +583,11 @@ func main() {
 					{
 						ConditionGroups: []*policy.ConditionGroup{
 							{
-								BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+								BooleanOperator: policy.BooleanAnd,
 								Conditions: []*policy.Condition{
 									{
 										SubjectExternalSelectorValue: ".clientId",
-										Operator: policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+										Operator: policy.OperatorIn,
 										SubjectExternalValues:        []string{"opentdf"},
 									},
 								},


### PR DESCRIPTION
## Summary

- Update Go SDK code samples to use the new shorthand enum constants (`policy.OperatorIn`, `policy.BooleanAnd`, `policy.RuleAnyOf`) instead of verbose proto enum names
- Update JS SDK imports to use barrel exports from `@opentdf/sdk` instead of deep proto paths (`@opentdf/sdk/platform/policy/objects_pb.js`)
- Update JS SDK examples to use enum values (`ConditionBooleanTypeEnum.AND`) instead of string literals (`'CONDITION_BOOLEAN_TYPE_ENUM_AND'`)
- Update Java SDK inline examples in policy.mdx to use `PolicyEnums` shorthand constants
- Add `SdkVersion` badges with `NEXT` placeholders — replace with actual versions once SDK releases ship

### Companion PRs

| SDK | PR | Status |
|---|---|---|
| Go | opentdf/platform#3408 | Open |
| Java | opentdf/java-sdk#357 | Open |
| JavaScript | opentdf/web-sdk#928 | Open |

### Note on Java code samples

The `code_samples/java/` files are pulled from the java-sdk repo at build time via `docusaurus-plugin-remote-content`. They will update automatically once `javaSdkVersion` is bumped in `docusaurus.config.ts` after the java-sdk release containing opentdf/java-sdk#357.

## Test plan

- [x] `npm run build` passes
- [ ] Surge preview renders correctly
- [ ] Replace `NEXT` version placeholders after SDK releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated policy and quickstart code examples for Go, Java, and JavaScript to use simplified SDK enum constants for clearer, more idiomatic samples.
  * Switched JavaScript examples to use package entry-point imports instead of generated-module paths.
  * Added SDK version markers to code samples to show explicit language/version context and improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->