### PR TITLE
chore(docs): update otdfctl references to platform monorepo

### DIFF
--- a/.github/workflows/otdfctl-update.yaml
+++ b/.github/workflows/otdfctl-update.yaml
@@ -25,7 +25,7 @@ jobs:
           BUMP_MSG="Updated to"
           COMMIT_HASH=""
           BRANCH="otdfctl-update-$TAG"
-          PR_EXISTS=(gh pr list --state open --base main --head $BRANCH | grep -c $BRANCH)
+          PR_EXISTS=$(gh pr list --state open --base main --head $BRANCH | grep -c $BRANCH)
           # Check if PR exists for branch
           if [ $PR_EXISTS -eq 1 ]; then
             git checkout $BRANCH
@@ -38,7 +38,7 @@ jobs:
           git remote add platform https://github.com/opentdf/platform.git
           git fetch platform
           git read-tree --prefix "docs/otdfctl" -u "platform/$TAG:otdfctl/docs/man"
-          COMMIT_HASH=(git ls-remote --heads platform "refs/heads/$TAG" |awk '{ print $1}')
+          COMMIT_HASH=$(git ls-remote --heads platform "refs/heads/$TAG" | awk '{ print $1}')
           # Rename _index.md to index.md
           find docs/otdfctl -name "_index.md" -exec bash -c 'mv "$1" "${1/_index.md/index.md}"' _ {} \;
           # Add a generated file

--- a/.github/workflows/otdfctl-update.yaml
+++ b/.github/workflows/otdfctl-update.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'opentdf/otdfctl to update from'
+        description: 'opentdf/platform otdfctl tag to update from'
         required: true
         default: 'main'
   repository_dispatch:
@@ -35,16 +35,16 @@ jobs:
           # Remove the current docs/otdfctl directory
           rm -rf docs/otdfctl
           # Add docs from remote
-          git remote add otdfctl https://github.com/opentdf/otdfctl.git
-          git fetch otdfctl
-          git read-tree --prefix "docs/otdfctl" -u "otdfctl/$TAG:docs/man"
-          COMMIT_HASH=(git ls-remote --heads otdfctl "refs/heads/$TAG" |awk '{ print $1}')
+          git remote add platform https://github.com/opentdf/platform.git
+          git fetch platform
+          git read-tree --prefix "docs/otdfctl" -u "platform/$TAG:otdfctl/docs/man"
+          COMMIT_HASH=(git ls-remote --heads platform "refs/heads/$TAG" |awk '{ print $1}')
           # Rename _index.md to index.md
           find docs/otdfctl -name "_index.md" -exec bash -c 'mv "$1" "${1/_index.md/index.md}"' _ {} \;
           # Add a generated file
           echo "This directory is generated any manual changes will be lost.\n
             date: $(date)
-            source: https://github.com/opentdf/otdfctl/tree/$TAG
+            source: https://github.com/opentdf/platform/tree/$TAG/otdfctl
             event: ${{github.event}}
             actor: ${{github.triggering_actor}}\n" > docs/otdfctl/GENERATED.txt
           # Commit changes

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The documentation site pulls content from multiple upstream repositories using D
 
 - `PLATFORM_BRANCH` - Controls which branch to fetch from `opentdf/platform` (default: `main`)
 - `SPEC_BRANCH` - Controls which branch to fetch from `opentdf/spec` (default: `main`)
-- `OTDFCTL_BRANCH` - Controls which branch to fetch from `opentdf/otdfctl` (default: `main`)
+- `OTDFCTL_BRANCH` - Controls which branch to fetch from `opentdf/platform` for CLI docs (default: `main`)
 
 **Examples:**
 

--- a/docs/components/policy/keymanagement/base_key.md
+++ b/docs/components/policy/keymanagement/base_key.md
@@ -15,7 +15,7 @@ You must have admin permission to use any key operations.
 
 When using the [kas-registry proto](https://github.com/opentdf/platform/blob/5221cf41079fc43a3966e17c6f3e0d3cf8a16730/service/policy/kasregistry/key_access_server_registry.proto#L692-L696) and an active connection to the platform you can use the above base key rpcs to set and retrieve the base key.
 
-[otdfctl base key](https://github.com/opentdf/otdfctl/tree/main/docs/man/policy/kas-registry/key/base) provides documentation on how to set / get base keys with the OpenTDF CLI.
+[otdfctl base key](https://github.com/opentdf/platform/tree/main/otdfctl/docs/man/policy/kas-registry/key/base) provides documentation on how to set / get base keys with the OpenTDF CLI.
 
 ## Effects of using base key
 

--- a/docs/components/policy/keymanagement/quickstart.md
+++ b/docs/components/policy/keymanagement/quickstart.md
@@ -36,7 +36,7 @@ be helpful for migrations.
 ## Creating a key
 
 :::note
-You can also perform all key commands with the [OpenTDF CLI](https://github.com/opentdf/otdfctl)
+You can also perform all key commands with the [OpenTDF CLI](https://github.com/opentdf/platform/tree/main/otdfctl)
 :::
 
 1. You should already have created and registered a **Key Access Server** with the platform via the [Create Key Access Server Endpoint](https://github.com/opentdf/platform/blob/6203fbaebcdd57b5b3437679465149f8ff395484/service/policy/kasregistry/key_access_server_registry.proto#L59).

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -40,7 +40,7 @@ This guide will walk you through setting up a new platform locally and walk you 
 ## Pre-requisites
 
 - A copy of the `otdfctl` CLI.
-  - [Download the latest release](https://github.com/opentdf/otdfctl/releases)
+  - [Download the latest release](https://github.com/opentdf/platform/releases?q=otdfctl)
   
 - A tool to run the compose file.
   - [Podman](https://podman.io/)

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -338,7 +338,7 @@ If the certificate import fails during installation, you'll need to import it ma
 </details>
 
 The installer will:
-- Download and install the [otdfctl CLI](https://github.com/opentdf/otdfctl)
+- Download and install the [otdfctl CLI](https://github.com/opentdf/platform/tree/main/otdfctl)
 - Verify Docker is running
 - Add entries to /etc/hosts (requires sudo)
 - Download and start all services (Platform, Keycloak, PostgreSQL, Caddy)

--- a/docs/guides/subject-mapping-guide.md
+++ b/docs/guides/subject-mapping-guide.md
@@ -710,7 +710,7 @@ otdfctl policy subject-condition-sets list
 --action 891cfe85-b381-4f85-9699-5f7dbfe2a9ab
 ```
 
-See the [actions reference](https://github.com/opentdf/otdfctl/blob/main/docs/man/policy/actions/_index.md) for more details.
+See the [actions reference](https://github.com/opentdf/platform/blob/main/otdfctl/docs/man/policy/actions/_index.md) for more details.
 
 ### Error: Token Claim Not Appearing in Entitlements
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -13,7 +13,7 @@ import ReleaseNotes from '@site/src/components/ReleaseNotes';
     <ReleaseNotes repo="opentdf/platform" filter="service"/>
   </TabItem>
   <TabItem value="cli" label="CLI (otdfctl)">
-    <ReleaseNotes repo="opentdf/otdfctl" />
+    <ReleaseNotes repo="opentdf/platform" filter="otdfctl" />
   </TabItem>
   <TabItem value="sdk-go" label="Go SDK">
     <ReleaseNotes repo="opentdf/platform" filter="sdk" />

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,7 +19,7 @@ preprocessOpenApiSpecs().catch(error => {
     process.exit(1);
 });
 
-const otdfctl = listRemote.createRepo("opentdf", "otdfctl", "main");
+const otdfctl = listRemote.createRepo("opentdf", "platform", "main");
 
 const javaSdkVersion = "0.11.1";
 const gtmId = "GTM-MKRLN6NL"; 
@@ -202,7 +202,7 @@ const config: Config = {
             { label: "Quickstart", to: "/quickstart" },
             { label: "SDKs", to: "/sdks" },
             { label: "Platform", href: "https://github.com/opentdf/platform" },
-            { label: "CLI Reference", href: "https://github.com/opentdf/otdfctl" },
+            { label: "CLI Reference", href: "https://github.com/opentdf/platform/tree/main/otdfctl" },
           ],
         },
         {
@@ -306,7 +306,7 @@ const config: Config = {
         id: "otdfctl",
         outDir: "docs/components/cli",
         sourceBaseUrl: listRemote.buildRepoRawBaseUrl(otdfctl),
-        documents: listRemote.listDocuments(otdfctl, ["docs/man/**/*.md"], []),
+        documents: listRemote.listDocuments(otdfctl, ["otdfctl/docs/man/**/*.md"], []),
         modifyContent: (filename, content) => {
           const baseCommand = "otdfctl";
           let commandTitle, command, subcommand;
@@ -314,7 +314,7 @@ const config: Config = {
           let nextFilename = filename
             .replace(/\.md$/, ".mdx")
             .replace(/\/_index.mdx$/, "/index.mdx")
-            .replace(/^docs\/man\//, "");
+            .replace(/^otdfctl\/docs\/man\//, "");
 
           if (nextFilename === "index.mdx") {
             nextFilename = "index.mdx";

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,7 +19,7 @@ preprocessOpenApiSpecs().catch(error => {
     process.exit(1);
 });
 
-const otdfctl = listRemote.createRepo("opentdf", "platform", "main");
+const otdfctl = listRemote.createRepo("opentdf", "platform", process.env.OTDFCTL_BRANCH || "main");
 
 const javaSdkVersion = "0.11.1";
 const gtmId = "GTM-MKRLN6NL"; 

--- a/src/components/landing/DeveloperFirst.tsx
+++ b/src/components/landing/DeveloperFirst.tsx
@@ -33,7 +33,7 @@ const sdks = [
     name: "CLI",
     lang: "otdfctl",
     install: null,
-    releaseUrl: "https://github.com/opentdf/otdfctl/releases/latest",
+    releaseUrl: "https://github.com/opentdf/platform/releases?q=otdfctl",
     colorClass: "sdk-cli",
     icon: ">_",
     href: "https://opentdf.io/components/cli",

--- a/static/quickstart/install.sh
+++ b/static/quickstart/install.sh
@@ -129,9 +129,9 @@ install_otdfctl() {
     echo -e "${BLUE}→${NC} Installing otdfctl CLI..."
 
     # Get the latest release version
-    RELEASE_URL="https://api.github.com/repos/opentdf/otdfctl/releases/latest"
+    RELEASE_URL="https://api.github.com/repos/opentdf/platform/releases"
     if [[ "$OPENTDF_VERSION" == "latest" ]]; then
-        VERSION=$(curl -s "$RELEASE_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        VERSION=$(curl -s "$RELEASE_URL" | grep '"tag_name": "otdfctl/' | head -1 | sed -E 's/.*"otdfctl\/([^"]+)".*/\1/')
         if [ -z "$VERSION" ]; then
             echo -e "${RED}✗ Could not determine latest otdfctl version${NC}"
             exit 1
@@ -168,7 +168,7 @@ install_otdfctl() {
     # Remove 'v' prefix if present
     VERSION_NUM="${VERSION#v}"
     ARCHIVE_NAME="otdfctl-${VERSION_NUM}-${PLATFORM}.${EXTENSION}"
-    DOWNLOAD_URL="https://github.com/opentdf/otdfctl/releases/download/${VERSION}/${ARCHIVE_NAME}"
+    DOWNLOAD_URL="https://github.com/opentdf/platform/releases/download/otdfctl/${VERSION}/${ARCHIVE_NAME}"
 
     # Download and extract
     local TEMP_DIR


### PR DESCRIPTION
## Summary

- Update all `opentdf/otdfctl` references to `opentdf/platform` monorepo
- The `opentdf/otdfctl` repo is archived; CLI now lives under `otdfctl/` in the platform repo
- Updates install script, docusaurus remote content plugin, GitHub Actions workflow, and doc links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation links and references to point to the centralized platform repository and adjusted displayed release notes scope.

* **Chores**
  * Updated installer and download links to fetch CLI releases from the centralized platform repository.
  * Updated build/workflow steps to pull CLI documentation and metadata from the centralized platform source.
  * Updated UI link for downloading the latest CLI release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->