### PR TITLE
feat(docs): document SDK.IsHealthy and link unresolved type references

### DIFF
--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -602,7 +602,7 @@ await platform.v2.authorization.getDecision({ ... })
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `entityIdentifier` | [`EntityIdentifier`](#entityidentifier) | Yes | The entity requesting access. Use [helpers](#entityidentifier) like `ForEmail(...)` (Go) or `EntityIdentifiers.forEmail(...)` (Java/JS). |
-| `action` | `Action` | Yes | The action being performed (e.g., `decrypt`, `read`). |
+| `action` | [`Action`](/sdks/policy#action) | Yes | The action being performed (e.g., `decrypt`, `read`). |
 | `resource` | [`Resource`](#resource) | Yes | The resource being accessed. Use [helpers](#resource) like `ForAttributeValues(...)` (Go) or `Resources.forAttributeValues(...)` (Java/JS). |
 
 **Example**
@@ -827,14 +827,16 @@ await platform.v2.authorization.getDecisionBulk({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `decisionRequests` | `[]GetDecisionMultiResourceRequest` | Yes | Each entry contains an entity, action, and one or more resources to evaluate. |
+| `decisionRequests` | [`[]GetDecisionMultiResourceRequest`](#getdecisionmultiresourcerequest) | Yes | Each entry contains an entity, action, and one or more resources to evaluate. |
+
+### GetDecisionMultiResourceRequest
 
 Each `GetDecisionMultiResourceRequest` contains:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `entityIdentifier` | [`EntityIdentifier`](#entityidentifier) | Yes | The entity requesting access. |
-| `action` | `Action` | Yes | The action being performed. |
+| `action` | [`Action`](/sdks/policy#action) | Yes | The action being performed. |
 | `resources` | [`[]Resource`](#resource) | Yes | Resources to evaluate, each with an `ephemeralId` for correlation. |
 
 **Example**

--- a/docs/sdks/authorization.mdx
+++ b/docs/sdks/authorization.mdx
@@ -789,7 +789,7 @@ if (decision?.decision === Decision.PERMIT) {
 
 **Returns**
 
-A [ResourceDecision](#resourcedecision) with a [Decision](#decision) (permit/deny) and any required [obligations](/components/policy/obligations) the consuming application must enforce.
+A [ResourceDecision](#resourcedecision) with a [Decision](#decision) (permit/deny) and any required [obligations](/sdks/obligations) the consuming application must enforce.
 
 ---
 
@@ -1116,7 +1116,7 @@ Returned by [GetEntitlements](#getentitlements). One per entity, mapping attribu
 | Field | Type | Description |
 |-------|------|-------------|
 | `ephemeralId` | `string` | Correlates with the entity in the request. |
-| `actionsPerAttributeValueFqn` | `map<string, ActionsList>` | Keys are attribute value FQNs. Values are lists of [actions](/sdks/policy#action) the entity can perform on data carrying that attribute value. |
+| `actionsPerAttributeValueFqn` | [`map<string, ActionsList>`](#actionslist) | Keys are attribute value FQNs. Values are lists of [actions](/sdks/policy#action) the entity can perform on data carrying that attribute value. |
 
 ```go
 for _, e := range resp.GetEntitlements() {
@@ -1133,6 +1133,16 @@ for (const e of resp.entitlements) {
   }
 }
 ```
+
+### ActionsList
+
+A thin wrapper around a list of [`Action`](/sdks/policy#action) used as the value type in `EntityEntitlements.actionsPerAttributeValueFqn`. The wrapper exists because protobuf maps cannot have repeated value types directly.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actions` | [`[]Action`](/sdks/policy#action) | The actions the entity can perform on data carrying the keyed attribute value. |
+
+In Go, reach the underlying slice with `actionsList.GetActions()`. In Java, `actionsList.getActionsList()`. In JavaScript, the value is surfaced directly as an `Actions` object whose `.actions` field is the array.
 
 ### GetDecisionMultiResourceResponse
 

--- a/docs/sdks/platform-client.mdx
+++ b/docs/sdks/platform-client.mdx
@@ -6,6 +6,7 @@ title: Overview
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import JsAuthNote from '../../code_samples/js_auth_note.mdx'
+import SdkVersion from '@site/src/components/SdkVersion';
 
 # Overview
 
@@ -89,6 +90,36 @@ const platform = new PlatformClient({ ...auth, platformUrl: 'http://localhost:80
 
 </TabItem>
 </Tabs>
+
+## Health checks
+
+`IsHealthy` reports whether the platform is reachable and serving requests. Use it in readiness probes, smoke tests, or to gate startup logic on platform availability.
+
+<SdkVersion language="go" version="0.18.0" source="opentdf" />
+
+```go
+healthy, err := client.IsHealthy(ctx)
+if err != nil {
+    // transport failure or context cancellation
+    log.Printf("platform unreachable: %v", err)
+    return
+}
+if !healthy {
+    // reachable, but reports NOT_SERVING or UNKNOWN
+    log.Println("platform is not ready")
+}
+```
+
+The check honors the supplied `context.Context` for deadlines and cancellation, and propagates OTEL tracing when `otelconnect.NewInterceptor` is registered via `WithExtraClientOptions`.
+
+### Return values
+
+| Result | Meaning |
+|---|---|
+| `(true, nil)` | Platform reports `SERVING`. |
+| `(false, nil)` | Platform is reachable but reports `NOT_SERVING` or `UNKNOWN`. |
+| `(false, err)` | Transport failure or context cancellation. The error wraps `sdk.ErrPlatformUnreachable`. |
+| `(false, sdk.ErrHealthCheckUnsupported)` | The SDK is configured in IPC mode, which does not support health checks. |
 
 ## Response Objects
 

--- a/docs/sdks/platform-client.mdx
+++ b/docs/sdks/platform-client.mdx
@@ -100,8 +100,9 @@ const platform = new PlatformClient({ ...auth, platformUrl: 'http://localhost:80
 ```go
 healthy, err := client.IsHealthy(ctx)
 if err != nil {
-    // transport failure or context cancellation
-    log.Printf("platform unreachable: %v", err)
+    // err is sdk.ErrHealthCheckUnsupported (IPC mode), or wraps
+    // sdk.ErrPlatformUnreachable on transport failure or ctx cancellation
+    log.Printf("health check failed: %v", err)
     return
 }
 if !healthy {

--- a/docs/sdks/policy.mdx
+++ b/docs/sdks/policy.mdx
@@ -1616,7 +1616,7 @@ await platform.v1.subjectMapping.updateSubjectConditionSet({ ... })
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | `string` (UUID) | Yes | The subject condition set ID to update. |
-| `subjectSets` | `[]SubjectSet` | No | Replaces the entire condition tree. Omit to update metadata only. |
+| `subjectSets` | [`[]SubjectSet`](#subjectset) | No | Replaces the entire condition tree. Omit to update metadata only. |
 | `metadata` | [`Metadata`](#metadata) | No | Optional [labels](#metadata). |
 | `metadataUpdateBehavior` | `string` | No | `METADATA_UPDATE_ENUM_REPLACE` or `METADATA_UPDATE_ENUM_EXTEND` (default). |
 
@@ -2345,7 +2345,7 @@ await platform.v1.subjectMapping.matchSubjectMappings({ ... })
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `subjectProperties` | `[]SubjectProperty` | Yes | Key-value pairs from an entity's claims. Each has `externalSelectorValue` (the claim path, e.g., `.clientId`) and `externalValue` (the claim value). |
+| `subjectProperties` | [`[]SubjectProperty`](#subjectproperty) | Yes | Key-value pairs from an entity's claims. Each has `externalSelectorValue` (the claim path, e.g., `.clientId`) and `externalValue` (the claim value). |
 
 **Example**
 

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -628,7 +628,7 @@ func (s SDK) PrepareBulkDecrypt(ctx context.Context, opts ...BulkDecryptOption) 
 |-------|------|-------------|
 | `Reader` | `io.ReadSeeker` | Source of the encrypted TDF. |
 | `Writer` | `io.Writer` | Destination for the decrypted plaintext. |
-| `TriggeredObligations` | `RequiredObligations` | Populated after rewrap with obligation FQNs required by this TDF. See [Obligations in bulk decrypt](#obligations-in-bulk-decrypt). |
+| `TriggeredObligations` | [`RequiredObligations`](#requiredobligations) | Populated after rewrap with obligation FQNs required by this TDF. See [Obligations in bulk decrypt](#obligations-in-bulk-decrypt). |
 
 **Options**
 
@@ -1423,19 +1423,19 @@ The `Manifest` type is returned by [`CreateTDF`](#createtdf) and accessible via 
 | Field | Type | Description |
 |-------|------|-------------|
 | `TDFVersion` | `string` | TDF spec version (e.g. `"4.3.0"`). Serialized as `schemaVersion` in the manifest JSON. |
-| `EncryptionInformation` | `EncryptionInformation` | Encryption method, key access objects, and integrity information. |
-| `Payload` | `Payload` | Metadata about the encrypted payload. |
-| `Assertions` | `[]Assertion` | Cryptographically bound or signed statements attached to the TDF. Empty if none were added at encrypt time. |
+| `EncryptionInformation` | [`EncryptionInformation`](#encryptioninformation) | Encryption method, key access objects, and integrity information. |
+| `Payload` | [`Payload`](#manifest-payload) | Metadata about the encrypted payload. |
+| `Assertions` | [`[]Assertion`](#assertion) | Cryptographically bound or signed statements attached to the TDF. Empty if none were added at encrypt time. |
 
-**EncryptionInformation Fields**
+#### EncryptionInformation
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `KeyAccessObjs` | `[]KeyAccess` | One entry per KAS holding a key grant. Split TDFs have multiple entries. |
+| `KeyAccessObjs` | [`[]KeyAccess`](#keyaccess) | One entry per KAS holding a key grant. Split TDFs have multiple entries. |
 | `Method.Algorithm` | `string` | Encryption algorithm (e.g. `"AES-256-GCM"`). |
 | `Policy` | `string` | Base64-encoded policy object. Use [`tdfReader.Policy()`](#policy) to decode. |
 
-**KeyAccess Fields**
+#### KeyAccess
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1444,7 +1444,7 @@ The `Manifest` type is returned by [`CreateTDF`](#createtdf) and accessible via 
 | `SplitID` | `string` | Key split identifier. Entries sharing the same ID share a key segment; different IDs represent independent splits. |
 | `KID` | `string` | Key identifier on the KAS, if set. |
 
-**Payload Fields**
+#### Payload (manifest field) {#manifest-payload}
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1503,11 +1503,24 @@ for _, a := range manifest.Assertions {
 | Field | Type | Description |
 |-------|------|-------------|
 | `ID` | `string` | Assertion identifier (matches the `AssertionConfig.ID` used at encrypt time). |
-| `Type` | `AssertionType` | `"handling"` or `"other"`. |
-| `Scope` | `Scope` | `"tdo"` or `"payload"`. |
-| `AppliesToState` | `AppliesToState` | `"encrypted"` or `"unencrypted"`. |
-| `Statement` | `Statement` | The assertion content. |
-| `Binding` | `Binding` | Cryptographic binding — `Method` (`"jws"`) and `Signature` (JWS token). |
+| `Type` | [`AssertionType`](#assertion-types) | `"handling"` or `"other"`. |
+| `Scope` | [`Scope`](#scopes) | `"tdo"` or `"payload"`. |
+| `AppliesToState` | [`AppliesToState`](#appliestostate) | `"encrypted"` or `"unencrypted"`. |
+| `Statement` | [`Statement`](#statement-type) | The assertion content. |
+| `Binding` | [`Binding`](#binding) | Cryptographic binding — `Method` (`"jws"`) and `Signature` (JWS token). |
+
+---
+
+### Binding
+
+The cryptographic binding attached to a signed [`Assertion`](#assertion).
+
+**Fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Method` | `string` | Binding method. Currently `"jws"`. |
+| `Signature` | `string` | The JWS token that binds the assertion to the TDF. |
 
 ---
 
@@ -1542,8 +1555,22 @@ Passed to `WithAssertionVerificationKeys` when loading a TDF. Maps assertion IDs
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `DefaultKey` | `AssertionKey` | Fallback key used when no ID-specific key is found. |
+| `DefaultKey` | [`AssertionKey`](#assertionkey) | Fallback key used when no ID-specific key is found. |
 | `Keys` | `map[string]AssertionKey` | Map of assertion ID to verification key. |
+
+---
+
+### RequiredObligations
+
+Returned by [`Reader.Obligations()`](#obligations) and populated on each `BulkTDF.TriggeredObligations` field after [`PrepareBulkDecrypt`](#bulkdecrypt). Wraps the obligation FQNs the platform requires the consuming application to enforce before granting access to the TDF's payload.
+
+Supported in the Go and JavaScript SDKs.
+
+**Fields**
+
+| Field | Go | JavaScript | Description |
+|-------|-----|------------|-------------|
+| FQNs / fqns | `FQNs []string` | `fqns: string[]` | Obligation value FQNs required for this TDF. Empty when no obligations are triggered. |
 
 ---
 


### PR DESCRIPTION
## Summary

Two related changes in one PR:

### 1. Document `SDK.IsHealthy(ctx)` reachability probe

Adds a **Health checks** section to `docs/sdks/platform-client.mdx` covering the new `SDK.IsHealthy(ctx) (bool, error)` method shipped in opentdf/platform sdk v0.18.0 (opentdf/platform#3412).

The section documents:

- The `(bool, error)` contract and when to reach for it (readiness probes, smoke tests, startup gating)
- `SERVING` / `NOT_SERVING` / `UNKNOWN` return semantics
- IPC mode (`ErrHealthCheckUnsupported`) and transport failure (`ErrPlatformUnreachable`) sentinels
- Context propagation and OTEL tracing behavior

Go-only — IsHealthy is a server-side readiness concern and is not planned for the web SDK.

### 2. Link unresolved type references in SDK reference tables

Several PascalCase type cells in SDK reference tables were rendering as plain text instead of links to their definitions, forcing readers to scroll or grep to learn the type's shape.

**`authorization.mdx`**
- Link `Action` cells to `/sdks/policy#action`
- Add `### GetDecisionMultiResourceRequest` heading so its parameter cell resolves to a real anchor

**`tdf.mdx`**
- Add `RequiredObligations` to the Type Reference and link the `TriggeredObligations` cell
- Promote Manifest sub-tables (`EncryptionInformation`, `KeyAccess`, `Payload`) to H4 subheadings; disambiguate Payload with `{#manifest-payload}` since the TDF Reader method already owns `#payload`
- Fully link the `Assertion` fields table (`AssertionType`, `Scope`, `AppliesToState`, `Statement`, `Binding`) and add a `Binding` type-ref entry
- Link `AssertionKey` in `AssertionVerificationKeys.DefaultKey`

**`policy.mdx`**
- Link `SubjectSet` in `UpdateSubjectConditionSet` parameters
- Link `SubjectProperty` in `MatchSubjectMappings` parameters

## Test plan

- [x] `npm run build` passes — no new broken anchors introduced
- [x] `vale docs/sdks/platform-client.mdx` clean
- [ ] Surge preview renders the new section and link targets correctly
- [ ] Verify the `SdkVersion` badge shows `0.18.0` for Go

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved cross-references and internal links across authorization, policy, and TDF docs for clearer navigation.
  * Added a platform health-checks section with usage examples, return-value guidance, and behavior notes for different modes.
  * Introduced new subsections (ActionsList, Binding, RequiredObligations) and linked type references to clarify fields and access patterns across SDKs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->