### PR TITLE
fix(docs): remove broken STYLE_GUIDE.md link and fix docs site URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About This Repository
 
-This repository contains the source code for the [OpenTDF documentation website](https://opentdf.io), built using [Docusaurus](https://docusaurus.io/). The documentation provides comprehensive guides, tutorials, and reference materials for developers and organizations implementing data-centric security with OpenTDF.
+This repository contains the source code for the [OpenTDF documentation website](https://docs.opentdf.io), built using [Docusaurus](https://docusaurus.io/). The documentation provides comprehensive guides, tutorials, and reference materials for developers and organizations implementing data-centric security with OpenTDF.
 
 ## What is OpenTDF?
 
@@ -33,11 +33,9 @@ We welcome contributions to improve our documentation! Please see our [Contribut
 - Review and approval process
 - Technical setup for contributors
 
-For style guidelines, please refer to our [Style Guide](STYLE_GUIDE.md).
-
 ## Quick Links
 
-- **Live Documentation**: [docs.opentdf.io](https://opentdf.io)
+- **Live Documentation**: [docs.opentdf.io](https://docs.opentdf.io)
 - **OpenTDF Platform**: [github.com/opentdf/platform](https://github.com/opentdf/platform)
 - **TDF Format Spec**: [github.com/opentdf/spec](https://github.com/opentdf/spec)
 - **OpenTDF Organization**: [github.com/opentdf](https://github.com/opentdf)


### PR DESCRIPTION
## Summary

Fixes two small issues in `README.md`:

1. **Broken link removed** — The Contributing section referenced `[Style Guide](STYLE_GUIDE.md)`, but `STYLE_GUIDE.md` does not exist in the repository (returns 404). Removed the dangling reference.

2. **Documentation URL corrected** — The "Live Documentation" quick link and the "About This Repository" link both pointed to `https://opentdf.io`, but the actual documentation site domain is `docs.opentdf.io` (confirmed via `static/CNAME`). Updated both URLs to `https://docs.opentdf.io`.

## What changed
- Removed the `For style guidelines, please refer to our [Style Guide](STYLE_GUIDE.md).` line
- Changed `https://opentdf.io` → `https://docs.opentdf.io` in two places

## Test plan
- [ ] Verify the "Live Documentation" link resolves correctly
- [ ] Verify no remaining references to `STYLE_GUIDE.md`
- [ ] Build passes (`npm run build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reflect current resources.
  * Simplified contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->