### PR TITLE
fix(docs): pin quickstart to pre-PQC platform image and config

### DIFF
--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -187,7 +187,7 @@ services:
 
   # Provision Keycloak with initial configuration
   platform-provision-keycloak:
-    image: registry.opentdf.io/platform:nightly-a29f108
+    image: registry.opentdf.io/platform:nightly
     command: ["provision", "keycloak", "-e", "https://keycloak.opentdf.local:9443/auth", "-f", "/configs/keycloak_data.yaml"]
     depends_on:
       keycloak:
@@ -199,6 +199,8 @@ services:
       download-keycloak-data:
         condition: service_completed_successfully
       generate-keys:
+        condition: service_completed_successfully
+      generate-pqc-keys:
         condition: service_completed_successfully
     volumes:
       - configs:/configs:ro
@@ -227,7 +229,7 @@ services:
 
   # Add sample attributes and metadata  
   platform-provision-fixtures:
-    image: registry.opentdf.io/platform:nightly-a29f108
+    image: registry.opentdf.io/platform:nightly
     command: ["provision", "fixtures", "--config-file", "/configs/opentdf.yaml"]
     working_dir: /configs
     depends_on:
@@ -238,6 +240,8 @@ services:
       prepare-fixtures:
         condition: service_completed_successfully
       generate-keys:
+        condition: service_completed_successfully
+      generate-pqc-keys:
         condition: service_completed_successfully
     volumes:
       - configs:/configs:ro
@@ -274,7 +278,7 @@ services:
 
   # Main OpenTDF Platform server
   platform:
-    image: registry.opentdf.io/platform:nightly-a29f108
+    image: registry.opentdf.io/platform:nightly
     command: ["start", "--config-file", "/configs/opentdf.yaml"]
     depends_on:
       platform-provision-fixtures:
@@ -284,6 +288,8 @@ services:
       opentdfdb:
         condition: service_healthy
       generate-keys:
+        condition: service_completed_successfully
+      generate-pqc-keys:
         condition: service_completed_successfully
       prepare-ca-certs:
         condition: service_completed_successfully
@@ -320,6 +326,8 @@ services:
     depends_on:
       generate-keys:
         condition: service_completed_successfully
+      generate-pqc-keys:
+        condition: service_completed_successfully
     command:
       - sh
       - -c
@@ -336,7 +344,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/a29f1087/opentdf-example.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/main/opentdf-example.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443
@@ -518,6 +526,39 @@ services:
         echo "Keys generated successfully"
     environment:
       JAVA_OPTS_APPEND: "${JAVA_OPTS_APPEND:-}"
+    restart: "no"
+
+  # Generate hybrid post-quantum KAS keys (X-Wing, P256+ML-KEM-768, P384+ML-KEM-1024).
+  # Uses a Go image to build and run the keygen from the platform source.
+  generate-pqc-keys:
+    image: golang:1.24-alpine
+    volumes:
+      - keys:/keys
+    depends_on:
+      generate-keys:
+        condition: service_completed_successfully
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        apk add --no-cache git
+        WORKDIR=$(mktemp -d)
+        cd "$$WORKDIR"
+        git init
+        git remote add origin https://github.com/opentdf/platform.git
+        git config core.sparseCheckout true
+        echo "go.work" >> .git/info/sparse-checkout
+        echo "lib/" >> .git/info/sparse-checkout
+        echo "service/cmd/keygen/" >> .git/info/sparse-checkout
+        echo "service/go.mod" >> .git/info/sparse-checkout
+        echo "service/go.sum" >> .git/info/sparse-checkout
+        echo "protocol/" >> .git/info/sparse-checkout
+        echo "sdk/" >> .git/info/sparse-checkout
+        git pull --depth 1 origin main
+        cd service
+        go run ./cmd/keygen -output /keys
+        echo "PQC keys generated successfully"
+        rm -rf "$$WORKDIR"
     restart: "no"
 
 volumes:

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -336,7 +336,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/main/opentdf-example.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/main/opentdf-dev.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -187,7 +187,7 @@ services:
 
   # Provision Keycloak with initial configuration
   platform-provision-keycloak:
-    image: registry.opentdf.io/platform:nightly
+    image: registry.opentdf.io/platform:nightly-a29f108
     command: ["provision", "keycloak", "-e", "https://keycloak.opentdf.local:9443/auth", "-f", "/configs/keycloak_data.yaml"]
     depends_on:
       keycloak:
@@ -199,8 +199,6 @@ services:
       download-keycloak-data:
         condition: service_completed_successfully
       generate-keys:
-        condition: service_completed_successfully
-      generate-pqc-keys:
         condition: service_completed_successfully
     volumes:
       - configs:/configs:ro
@@ -229,7 +227,7 @@ services:
 
   # Add sample attributes and metadata  
   platform-provision-fixtures:
-    image: registry.opentdf.io/platform:nightly
+    image: registry.opentdf.io/platform:nightly-a29f108
     command: ["provision", "fixtures", "--config-file", "/configs/opentdf.yaml"]
     working_dir: /configs
     depends_on:
@@ -240,8 +238,6 @@ services:
       prepare-fixtures:
         condition: service_completed_successfully
       generate-keys:
-        condition: service_completed_successfully
-      generate-pqc-keys:
         condition: service_completed_successfully
     volumes:
       - configs:/configs:ro
@@ -278,7 +274,7 @@ services:
 
   # Main OpenTDF Platform server
   platform:
-    image: registry.opentdf.io/platform:nightly
+    image: registry.opentdf.io/platform:nightly-a29f108
     command: ["start", "--config-file", "/configs/opentdf.yaml"]
     depends_on:
       platform-provision-fixtures:
@@ -288,8 +284,6 @@ services:
       opentdfdb:
         condition: service_healthy
       generate-keys:
-        condition: service_completed_successfully
-      generate-pqc-keys:
         condition: service_completed_successfully
       prepare-ca-certs:
         condition: service_completed_successfully
@@ -326,8 +320,6 @@ services:
     depends_on:
       generate-keys:
         condition: service_completed_successfully
-      generate-pqc-keys:
-        condition: service_completed_successfully
     command:
       - sh
       - -c
@@ -344,7 +336,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/main/opentdf-example.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/a29f1087/opentdf-example.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443
@@ -526,39 +518,6 @@ services:
         echo "Keys generated successfully"
     environment:
       JAVA_OPTS_APPEND: "${JAVA_OPTS_APPEND:-}"
-    restart: "no"
-
-  # Generate hybrid post-quantum KAS keys (X-Wing, P256+ML-KEM-768, P384+ML-KEM-1024).
-  # Uses a Go image to build and run the keygen from the platform source.
-  generate-pqc-keys:
-    image: golang:1.24-alpine
-    volumes:
-      - keys:/keys
-    depends_on:
-      generate-keys:
-        condition: service_completed_successfully
-    entrypoint: /bin/sh
-    command:
-      - -c
-      - |
-        apk add --no-cache git
-        WORKDIR=$(mktemp -d)
-        cd "$$WORKDIR"
-        git init
-        git remote add origin https://github.com/opentdf/platform.git
-        git config core.sparseCheckout true
-        echo "go.work" >> .git/info/sparse-checkout
-        echo "lib/" >> .git/info/sparse-checkout
-        echo "service/cmd/keygen/" >> .git/info/sparse-checkout
-        echo "service/go.mod" >> .git/info/sparse-checkout
-        echo "service/go.sum" >> .git/info/sparse-checkout
-        echo "protocol/" >> .git/info/sparse-checkout
-        echo "sdk/" >> .git/info/sparse-checkout
-        git pull --depth 1 origin main
-        cd service
-        go run ./cmd/keygen -output /keys
-        echo "PQC keys generated successfully"
-        rm -rf "$$WORKDIR"
     restart: "no"
 
 volumes:

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -187,7 +187,7 @@ services:
 
   # Provision Keycloak with initial configuration
   platform-provision-keycloak:
-    image: registry.opentdf.io/platform:nightly
+    image: registry.opentdf.io/platform:nightly-a29f108
     command: ["provision", "keycloak", "-e", "https://keycloak.opentdf.local:9443/auth", "-f", "/configs/keycloak_data.yaml"]
     depends_on:
       keycloak:
@@ -227,7 +227,7 @@ services:
 
   # Add sample attributes and metadata  
   platform-provision-fixtures:
-    image: registry.opentdf.io/platform:nightly
+    image: registry.opentdf.io/platform:nightly-a29f108
     command: ["provision", "fixtures", "--config-file", "/configs/opentdf.yaml"]
     working_dir: /configs
     depends_on:
@@ -274,7 +274,7 @@ services:
 
   # Main OpenTDF Platform server
   platform:
-    image: registry.opentdf.io/platform:nightly
+    image: registry.opentdf.io/platform:nightly-a29f108
     command: ["start", "--config-file", "/configs/opentdf.yaml"]
     depends_on:
       platform-provision-fixtures:
@@ -336,7 +336,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/service/v0.15.0/opentdf-example.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/a29f1087/opentdf-example.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -336,7 +336,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/main/opentdf-dev.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/service/v0.15.0/opentdf-example.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443


### PR DESCRIPTION
## Problem

The quickstart docker-compose downloads `opentdf-example.yaml` from `platform/main`, which now includes hybrid PQC keyring entries (`hpqt:xwing`, `hpqt:secp256r1-mlkem768`, `hpqt:secp384r1-mlkem1024`) added in opentdf/platform#3276. The quickstart's `generate-keys` service only creates RSA and EC keys via openssl — no PQC key files are generated. The platform crashes at startup:

```
failed to read private key file [/keys/kas-xwing-private.pem]: no such file or directory
```

Confirmed `main` is broken: https://github.com/opentdf/docs/actions/runs/27036624683

## Stopgap fix

Pin the platform image (`nightly-a29f108`) and config download to the last `main` commit before PQC landed. Image and config stay in sync, no PQC keys needed.

Long-term fix (add PQC key generation to the quickstart) will follow in a separate PR.

Fixes #336

## Test plan
- [x] BATS quickstart tests pass locally (23/23)
- [ ] CI docker-compose stack test passes on this branch
- [x] CI docker-compose stack test fails on `main` ([run](https://github.com/opentdf/docs/actions/runs/27036624683))

🤖 Generated with [Claude Code](https://claude.com/claude-code)