### PR TITLE
fix(docs): add PQC key generation to quickstart docker-compose

### DIFF
--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -187,7 +187,7 @@ services:
 
   # Provision Keycloak with initial configuration
   platform-provision-keycloak:
-    image: registry.opentdf.io/platform:nightly-a29f108
+    image: registry.opentdf.io/platform:nightly
     command: ["provision", "keycloak", "-e", "https://keycloak.opentdf.local:9443/auth", "-f", "/configs/keycloak_data.yaml"]
     depends_on:
       keycloak:
@@ -199,6 +199,8 @@ services:
       download-keycloak-data:
         condition: service_completed_successfully
       generate-keys:
+        condition: service_completed_successfully
+      generate-pqc-keys:
         condition: service_completed_successfully
     volumes:
       - configs:/configs:ro
@@ -227,7 +229,7 @@ services:
 
   # Add sample attributes and metadata  
   platform-provision-fixtures:
-    image: registry.opentdf.io/platform:nightly-a29f108
+    image: registry.opentdf.io/platform:nightly
     command: ["provision", "fixtures", "--config-file", "/configs/opentdf.yaml"]
     working_dir: /configs
     depends_on:
@@ -238,6 +240,8 @@ services:
       prepare-fixtures:
         condition: service_completed_successfully
       generate-keys:
+        condition: service_completed_successfully
+      generate-pqc-keys:
         condition: service_completed_successfully
     volumes:
       - configs:/configs:ro
@@ -274,7 +278,7 @@ services:
 
   # Main OpenTDF Platform server
   platform:
-    image: registry.opentdf.io/platform:nightly-a29f108
+    image: registry.opentdf.io/platform:nightly
     command: ["start", "--config-file", "/configs/opentdf.yaml"]
     depends_on:
       platform-provision-fixtures:
@@ -284,6 +288,8 @@ services:
       opentdfdb:
         condition: service_healthy
       generate-keys:
+        condition: service_completed_successfully
+      generate-pqc-keys:
         condition: service_completed_successfully
       prepare-ca-certs:
         condition: service_completed_successfully
@@ -320,6 +326,8 @@ services:
     depends_on:
       generate-keys:
         condition: service_completed_successfully
+      generate-pqc-keys:
+        condition: service_completed_successfully
     command:
       - sh
       - -c
@@ -336,7 +344,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/a29f1087/opentdf-example.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/service/v0.16.0/opentdf-example.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443
@@ -518,6 +526,39 @@ services:
         echo "Keys generated successfully"
     environment:
       JAVA_OPTS_APPEND: "${JAVA_OPTS_APPEND:-}"
+    restart: "no"
+
+  # Generate hybrid post-quantum KAS keys (X-Wing, P256+ML-KEM-768, P384+ML-KEM-1024).
+  # Uses a Go image to build and run the keygen from the platform source.
+  generate-pqc-keys:
+    image: golang:1.25-alpine
+    volumes:
+      - keys:/keys
+    depends_on:
+      generate-keys:
+        condition: service_completed_successfully
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        set -e
+        apk add --no-cache git
+        WORKDIR=$$(mktemp -d)
+        cd "$$WORKDIR"
+        git init -q
+        git remote add origin https://github.com/opentdf/platform.git
+        git config core.sparseCheckout true
+        echo "lib/" >> .git/info/sparse-checkout
+        echo "service/cmd/keygen/" >> .git/info/sparse-checkout
+        echo "service/go.mod" >> .git/info/sparse-checkout
+        echo "service/go.sum" >> .git/info/sparse-checkout
+        echo "protocol/" >> .git/info/sparse-checkout
+        echo "sdk/" >> .git/info/sparse-checkout
+        git pull --depth 1 -q origin service/v0.16.0
+        cd service
+        GOWORK=off go run ./cmd/keygen -output /keys
+        echo "PQC keys generated successfully"
+        rm -rf "$$WORKDIR"
     restart: "no"
 
 volumes:


### PR DESCRIPTION
## Summary
- Adds a `generate-pqc-keys` Docker Compose service that sparse-checkouts the platform's `service/cmd/keygen` and generates the hybrid post-quantum key files (X-Wing, P256+ML-KEM-768, P384+ML-KEM-1024) that `opentdf-example.yaml` now requires
- Pins config download to `service/v0.16.0` tag instead of `main` — prevents future config changes from breaking the quickstart (retro item from #336)
- Unpins platform image back to `nightly`
- Supersedes the stopgap pin in #337

## What changed
- New `generate-pqc-keys` service using `golang:1.24-alpine` (sparse checkout → `go run ./cmd/keygen` → PQC key PEMs to `/keys`)
- `platform-provision-keycloak`, `platform-provision-fixtures`, `platform`, and `fix-keys-permissions` depend on `generate-pqc-keys`
- Config download pinned to `service/v0.16.0` tag (not `main`)
- Platform image unpinned back to `nightly`

## Context
opentdf/platform#3276 added hybrid PQC keyring entries to `opentdf-example.yaml` but the quickstart's key generation only creates RSA/EC keys. See #336 for root-cause analysis. DSPX-3502 tracks cross-repo CI to prevent this class of break.

## Test plan
- [ ] CI docker-compose stack test passes (platform starts with PQC keys, health check returns 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hybrid post-quantum cryptography key generation capability for KAS during platform deployment, enhancing long-term security resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->