### PR TITLE
fix(docs): align quickstart PQC keygen and config with nightly platform image

### DIFF
--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -344,7 +344,7 @@ services:
     depends_on:
       init-volumes:
         condition: service_completed_successfully
-    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/service/v0.16.0/opentdf-example.yaml']
+    command: ['wget', '-O', '/configs/opentdf.yaml', 'https://raw.githubusercontent.com/opentdf/platform/main/opentdf-example.yaml']
     restart: "no"
 
   # Patch platform configuration to use keycloak.opentdf.local:9443
@@ -554,7 +554,7 @@ services:
         echo "service/go.sum" >> .git/info/sparse-checkout
         echo "protocol/" >> .git/info/sparse-checkout
         echo "sdk/" >> .git/info/sparse-checkout
-        git pull --depth 1 -q origin service/v0.16.0
+        git pull --depth 1 -q origin main
         cd service
         GOWORK=off go run ./cmd/keygen -output /keys
         echo "PQC keys generated successfully"


### PR DESCRIPTION
## Summary

- The quickstart docker-compose pinned keygen source and config download to `service/v0.16.0` while using the `nightly` platform image
- After opentdf/platform#3563 changed the hybrid key PEM format, the nightly image can no longer load keys generated by the v0.16.0 keygen, causing a 502 on `/healthz`
- Switch both refs to `main` so they stay in sync with the nightly image

Reported in https://github.com/opentdf/platform/discussions/3068#discussioncomment-17445343

Longer-term fix (adding `keygen` as a platform subcommand) tracked in opentdf/platform#3673.

## Test plan

- [x] `test-stack` CI job passes (currently [failing on main](https://github.com/opentdf/docs/actions/runs/28251987695))
- [x] Platform healthz returns 200 with PQC keys generated from `main`

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the local setup configuration to pull the latest example platform settings from the main branch.
  * Changed the key-generation setup to use the latest main branch source, helping ensure newer setup instructions stay in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->