### PR TITLE
docs(guides): make authentication and authorization guides SDK-agnostic

### DIFF
--- a/docs/guides/authentication-guide.mdx
+++ b/docs/guides/authentication-guide.mdx
@@ -6,12 +6,12 @@ sidebar_position: 5
 # Authentication Decision Guide
 
 :::info What you'll learn
-How to choose the right authentication method for your OpenTDF integration, based on your environment and use case.
+How to choose the right authentication method for your integration, based on your environment and use case.
 :::
 
-## How Authentication Works in OpenTDF
+## How Authentication Works
 
-The OpenTDF platform is a **resource server** — it does not manage user identities or issue tokens. Instead, you bring your own OIDC-compatible identity provider (IdP), such as [Keycloak](https://www.keycloak.org/) (the reference implementation), and configure the platform to trust it.
+The platform is a **resource server** — it does not manage user identities or issue tokens. Instead, you bring your own OIDC-compatible identity provider (IdP), such as [Keycloak](https://www.keycloak.org/) (the reference implementation), and configure the platform to trust it.
 
 The authentication flow looks like this:
 
@@ -19,7 +19,7 @@ The authentication flow looks like this:
 sequenceDiagram
     participant App as Your Application
     participant IdP as Identity Provider
-    participant Platform as OpenTDF Platform
+    participant Platform as Platform
 
     App->>IdP: Authenticate (credentials, token, cert)
     IdP-->>App: Access token (+ optional DPoP proof)
@@ -107,7 +107,7 @@ See [SDK code examples](/sdks/authentication#certificate-exchange-mtls) for Go a
 
 ### CLI Authentication
 
-For interactive CLI usage, `otdfctl` handles authentication for you:
+For interactive command-line use, a platform CLI can handle the OIDC login flow for you. The OpenTDF CLI (`otdfctl`):
 
 ```bash
 # Interactive login (opens browser)
@@ -144,7 +144,7 @@ These defaults are for development only. Do not use them in production.
 ### Production Checklist
 
 :::note
-OpenTDF does not prescribe a specific deployment strategy. This checklist covers authentication-related concerns — your infrastructure, scaling, and orchestration choices are up to you.
+The platform does not prescribe a specific deployment strategy. This checklist covers authentication-related concerns — your infrastructure, scaling, and orchestration choices are up to you.
 :::
 
 - [ ] **Enable TLS** — All connections to the platform and IdP must use HTTPS
@@ -154,7 +154,7 @@ OpenTDF does not prescribe a specific deployment strategy. This checklist covers
 - [ ] **Enable DPoP** — Sender-constrained tokens protect against token theft (see [DPoP docs](/sdks/authentication#dpop-sender-constrained-tokens))
 - [ ] **Set appropriate token lifetimes** — Short-lived access tokens with refresh tokens where applicable
 - [ ] **Use a production-grade IdP** — Configure Keycloak (or your chosen IdP) for high availability, backups, and monitoring
-- [ ] **Configure CORS** — Your application's origin must be registered as an allowed origin in both the IdP and the OpenTDF platform
+- [ ] **Configure CORS** — Your application's origin must be registered as an allowed origin in both the IdP and the platform
 
 ## Common Pitfalls
 
@@ -163,7 +163,7 @@ OpenTDF does not prescribe a specific deployment strategy. This checklist covers
 - **Check your IdP URL.** The platform discovers the IdP via its well-known OIDC endpoint. Verify the `oidcOrigin` (JS), token endpoint (Go), or platform endpoint (Java) is correct.
 - **Verify the client exists.** Ensure the client ID is registered in your IdP and the secret matches.
 - **Check token audience.** The platform rejects tokens whose `aud` claim doesn't match the expected audience. Decode your token (e.g., at [jwt.io](https://jwt.io)) and verify the `aud` field matches what's configured in your platform's YAML config under the auth section.
-- **Check CORS.** For browser-based apps, your application's origin must be allowed in both the IdP and OpenTDF platform configuration. CORS errors often appear as opaque network failures rather than clear 401 responses.
+- **Check CORS.** For browser-based apps, your application's origin must be allowed in both the IdP and platform configuration. CORS errors often appear as opaque network failures rather than clear 401 responses.
 
 ### "My token expired and I'm getting errors"
 

--- a/docs/guides/authentication-guide.mdx
+++ b/docs/guides/authentication-guide.mdx
@@ -154,7 +154,7 @@ The platform does not prescribe a specific deployment strategy. This checklist c
 - [ ] **Enable DPoP** — Sender-constrained tokens protect against token theft (see [DPoP docs](/sdks/authentication#dpop-sender-constrained-tokens))
 - [ ] **Set appropriate token lifetimes** — Short-lived access tokens with refresh tokens where applicable
 - [ ] **Use a production-grade IdP** — Configure Keycloak (or your chosen IdP) for high availability, backups, and monitoring
-- [ ] **Configure CORS** — Your application's origin must be registered as an allowed origin in both the IdP and the platform
+- [ ] **Configure CORS (browser-based apps)** — Your application's origin must be registered as an allowed origin in both the IdP and the platform
 
 ## Common Pitfalls
 

--- a/docs/guides/authorization-rest-api.mdx
+++ b/docs/guides/authorization-rest-api.mdx
@@ -112,7 +112,7 @@ def get_client_token(oidc_endpoint: str, client_id: str, client_secret: str):
 </Tabs>
 
 :::warning Audience configuration
-Your client credentials token must include an `audience` claim that matches your platform's URL. If the audience doesn't match, the platform will reject the token. Configure this in your IdP client settings — in Keycloak, set the client's audience mapper to include the platform URL.
+Your client credentials token must include an `aud` claim that matches your platform's URL. If the audience doesn't match, the platform will reject the token. Configure this in your IdP client settings — in Keycloak, set the client's audience mapper to include the platform URL.
 :::
 
 **Token caching:** The `expires_in` field tells you how long the token is valid (in seconds). Cache the token and refresh it before expiry — subtracting a 30-second buffer avoids race conditions on expiry boundaries.

--- a/docs/guides/authorization-rest-api.mdx
+++ b/docs/guides/authorization-rest-api.mdx
@@ -9,10 +9,10 @@ import TabItem from '@theme/TabItem';
 # Authorization REST API Guide
 
 :::info What you'll learn
-How to call the OpenTDF Authorization Service directly over HTTP — without an SDK — for server-side policy decisions in any language.
+How to call the Authorization Service directly over HTTP — without an SDK — for server-side policy decisions in any language.
 :::
 
-The OpenTDF SDKs wrap these APIs for Go, Java, and browser-based JavaScript. If you're building a **server-side integration** in Node.js, Python, Ruby, or another language without an SDK, you can call the Authorization Service directly over HTTP. The platform uses [ConnectRPC](https://connectrpc.com/), which natively supports HTTP/1.1 and HTTP/2, so every endpoint accepts standard JSON `POST` requests without requiring a separate gateway.
+The platform SDKs wrap these APIs for Go, Java, and browser-based JavaScript. If you're building a **server-side integration** in Node.js, Python, Ruby, or another language without an SDK, you can call the Authorization Service directly over HTTP. The platform uses [ConnectRPC](https://connectrpc.com/), which natively supports HTTP/1.1 and HTTP/2, so every endpoint accepts standard JSON `POST` requests without requiring a separate gateway.
 
 This guide covers the full integration pattern: authentication, health checks, authorization decisions, and production best practices. For detailed type definitions and SDK-based examples, see the [Authorization SDK reference](/sdks/authorization). For request/response schemas, see the [Authorization OpenAPI reference](/OpenAPI-clients/authorization/v2).
 
@@ -22,7 +22,7 @@ This guide covers the full integration pattern: authentication, health checks, a
 sequenceDiagram
     participant App as Your Application
     participant IdP as Identity Provider (Keycloak)
-    participant Platform as OpenTDF Platform
+    participant Platform as Platform
 
     App->>IdP: Client credentials grant
     IdP-->>App: Access token
@@ -112,7 +112,7 @@ def get_client_token(oidc_endpoint: str, client_id: str, client_secret: str):
 </Tabs>
 
 :::warning Audience configuration
-Your client credentials token must include an `audience` claim that matches your OpenTDF platform's URL. If the audience doesn't match, the platform will reject the token. Configure this in your IdP client settings — in Keycloak, set the client's audience mapper to include the platform URL.
+Your client credentials token must include an `audience` claim that matches your platform's URL. If the audience doesn't match, the platform will reject the token. Configure this in your IdP client settings — in Keycloak, set the client's audience mapper to include the platform URL.
 :::
 
 **Token caching:** The `expires_in` field tells you how long the token is valid (in seconds). Cache the token and refresh it before expiry — subtracting a 30-second buffer avoids race conditions on expiry boundaries.


### PR DESCRIPTION
## Summary

The Authentication Decision Guide and Authorization REST API Guide are vendored into downstream documentation sites where they apply to multiple SDKs, not just OpenTDF. This rewrites the **prose** to be SDK-agnostic so the same source reads correctly for any reader, while keeping all auth mechanics intact.

- Neutralize OpenTDF-centric framing to "the platform" — e.g. *"your OpenTDF integration"* → *"your integration"*, *"The OpenTDF platform is a resource server"* → *"The platform is a resource server"*, `## How Authentication Works in OpenTDF` → `## How Authentication Works`, and the mermaid `Platform` participant label.
- Generalize the CLI intro so it reads for non-OpenTDF readers, while **keeping** the concrete `otdfctl` example (it's the real OpenTDF CLI in this repo).
- Keep OpenTDF named where it refers to the actual product: the quickstart, Keycloak as the reference IdP, and the example namespace in the FQN table.
- **No mechanics changed** — OIDC flows, client credentials, DPoP, ConnectRPC endpoints, v1/v2 request shapes, and decision values are untouched. No frontmatter changes.

## Test plan

- [x] `vale` — 0 errors/warnings on both files
- [x] `npm run build` — completes; no new broken links or anchors on either page
- [x] `check-vendored-yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication methods, CLI login steps, and production checklist guidance.
  * Improved CORS troubleshooting guidance, including how errors may appear as opaque network failures.
  * Updated Authorization REST API documentation with direct HTTP/JSON usage details and ConnectRPC protocol support.
  * Refined platform terminology and OAuth audience-claim guidance throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->