### PR TITLE
docs(guides): make subject mapping and component docs SDK-agnostic

### DIFF
--- a/docs/components/key_access.md
+++ b/docs/components/key_access.md
@@ -1,6 +1,6 @@
 # Key Access Service
 
-The Key Access Server (KAS) manages the lifecycle of cryptographic keys and provides access to these keys for the encryption and decryption of TDFs. KAS serves as an out-of-the-box **Policy Enforcement Point (PEP)** for the OpenTDF platform.
+The Key Access Server (KAS) manages the lifecycle of cryptographic keys and provides access to these keys for the encryption and decryption of TDFs. KAS serves as an out-of-the-box **Policy Enforcement Point (PEP)** for the platform.
 
 ## RPC Methods
 

--- a/docs/components/key_access.md
+++ b/docs/components/key_access.md
@@ -1,6 +1,6 @@
 # Key Access Service
 
-The Key Access Server (KAS) manages the lifecycle of cryptographic keys and provides access to these keys for the encryption and decryption of TDFs. KAS serves as an out-of-the-box **Policy Enforcement Point (PEP)** for the platform.
+The Key Access Server (KAS) manages the lifecycle of cryptographic keys and provides access to these keys for the encryption and decryption of TDF files. KAS serves as an out-of-the-box **Policy Enforcement Point (PEP)** for the platform.
 
 ## RPC Methods
 

--- a/docs/components/policy/keymanagement/key_managers.md
+++ b/docs/components/policy/keymanagement/key_managers.md
@@ -5,7 +5,7 @@ slug: /components/policy/keymanagement/key_managers
 
 # Key Managers
 
-With the new key architecture the platform has added the flexibility for an organization to store keys outside of a key access server or the platform. For example, if your encryption keys are stored within AWS KMS, this is now totally possible through **key managers**.
+With the new key architecture, key management supports storing keys outside of a key access server or the platform itself. For example, if your encryption keys are stored within AWS KMS, this is now totally possible through **key managers**.
 
 ## What is a key manager?
 

--- a/docs/components/policy/keymanagement/key_managers.md
+++ b/docs/components/policy/keymanagement/key_managers.md
@@ -5,7 +5,7 @@ slug: /components/policy/keymanagement/key_managers
 
 # Key Managers
 
-With the new key architecture OpenTDF has added the flexibility for an organization to store keys outside of a key access server or the platform. For example, if you want to use OpenTDF and your encryption keys are stored within AWS KMS, this is now totally possible through **key managers**.
+With the new key architecture the platform has added the flexibility for an organization to store keys outside of a key access server or the platform. For example, if your encryption keys are stored within AWS KMS, this is now totally possible through **key managers**.
 
 ## What is a key manager?
 

--- a/docs/components/policy/subject_mappings.md
+++ b/docs/components/policy/subject_mappings.md
@@ -10,7 +10,7 @@ Subject Mappings evaluate conditions against an **Entity Representation** produc
 
 As data is bound to fully qualified Attribute Values when encrypted within a TDF, entities are associated with Attribute values through a mechanism called Subject Mappings.
 
-Entities (subjects, users, machines, etc.) are represented by their identity as determined from an identity provider (IdP). After an entity has securely authenticated with the IdP, the client's token (OIDC/OAUTH2) will include claims or attributes that describe that identity. Subject Mappings define how to map these identity attributes to actions on attribute values defined in the OpenTDF platform Policy. For more details on how the platform integrates with the IdP and how entities are resolved, refer to the [Authorization documentation](../authorization).
+Entities (subjects, users, machines, etc.) are represented by their identity as determined from an identity provider (IdP). After an entity has securely authenticated with the IdP, the client's token (OIDC/OAUTH2) will include claims or attributes that describe that identity. Subject Mappings define how to map these identity attributes to actions on attribute values defined in the platform Policy. For more details on how the platform integrates with the IdP and how entities are resolved, refer to the [Authorization documentation](../authorization).
 
 ```mermaid
 graph LR;

--- a/docs/guides/subject-mapping-guide.md
+++ b/docs/guides/subject-mapping-guide.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 # Subject Mapping Guide
 
 :::info What You'll Learn
-This guide explains how OpenTDF connects user identities from your Identity Provider (IdP) to attribute-based access control. You'll understand:
+This guide explains how the platform connects user identities from your Identity Provider (IdP) to attribute-based access control. You'll understand:
 - **Why** Subject Mappings exist (vs. direct IdP attribute mapping)
 - **How** authentication flows through to authorization decisions
 - **How** to scale Subject Mappings from exact-match to pattern-based conditions
@@ -17,7 +17,7 @@ This guide explains how OpenTDF connects user identities from your Identity Prov
 
 ### How It Actually Works
 
-OpenTDF uses a three-layer architecture:
+The platform uses a three-layer architecture:
 
 ```
 1. IdP Attributes       →  User has role=admin, department=finance
@@ -26,7 +26,7 @@ OpenTDF uses a three-layer architecture:
 2. Subject Mappings     →  IF role=admin THEN grant clearance/top_secret
                           (Entitlement Rules)
 
-3. OpenTDF Attributes   →  Document requires clearance/top_secret
+3. Platform Attributes  →  Document requires clearance/top_secret
                           (Resource Protection)
 ```
 
@@ -41,7 +41,7 @@ OpenTDF uses a three-layer architecture:
 sequenceDiagram
     participant User
     participant IdP as Identity Provider
-    box OpenTDF Services
+    box Platform Services
         participant KAS as Key Access Server
         participant Auth as Authorization Service
         participant ERS as Entity Resolution Service
@@ -369,7 +369,7 @@ Creating a separate Subject Mapping for every individual user is a **performance
 Instead of thinking "grant Alice access", think "grant anyone in the finance team access."
 :::
 
-All attribute values in OpenTDF must be explicitly created before they can be used — there is no "freeform" or "dynamic" attribute value type. Each `attribute_value_id` in a Subject Mapping must reference an existing, named value. The flexibility comes from how Subject Condition Sets match entity claims.
+All attribute values in the platform must be explicitly created before they can be used — there is no "freeform" or "dynamic" attribute value type. Each `attribute_value_id` in a Subject Mapping must reference an existing, named value. The flexibility comes from how Subject Condition Sets match entity claims.
 
 ### Anti-Pattern: One Mapping Per User
 
@@ -771,7 +771,7 @@ Use `.groups[]` (not `.groups`) to match each element:
 
 **4. Enable debug logging:**
 
-Contact your OpenTDF administrator to enable debug logging for Subject Mapping evaluation.
+Contact your platform administrator to enable debug logging for Subject Mapping evaluation.
 
 ### Error: User Has Entitlement But Still Gets DENY
 
@@ -848,7 +848,7 @@ otdfctl policy subject-mappings update \
 
 When Subject Mappings aren't working:
 
-- [ ] Verify OpenTDF platform is running and accessible
+- [ ] Verify the platform is running and accessible
 - [ ] Confirm user is authenticated (valid JWT token)
 - [ ] Check token contains expected claims (decode JWT)
 - [ ] Verify Subject Condition Set exists (`list` command)
@@ -968,9 +968,9 @@ The exact claim key for the client ID varies by IdP and ERS configuration — us
 
 ## FAQ
 
-**Q: Do I need to add roles in my IdP that match OpenTDF attributes?**
+**Q: Do I need to add roles in my IdP that match platform attributes?**
 
-**A:** No. IdP roles/claims describe WHO the user is. Subject Mappings convert those claims into OpenTDF entitlements (WHAT they can access). They are separate concerns.
+**A:** No. IdP roles/claims describe WHO the user is. Subject Mappings convert those claims into platform entitlements (WHAT they can access). They are separate concerns.
 
 **Q: What's the difference between IN and IN_CONTAINS?**
 


### PR DESCRIPTION
## Summary

Follow-up to the auth-guides PR (#360). Neutralizes OpenTDF-centric **framing prose** to "the platform" on the remaining pages that are vendored into the Virtru developer-docs site (`sdks: [opentdf, data-harbor]`), so the same source renders correctly on both opentdf.io and secure.virtru.com.

Same **balanced** approach as #360: only framing is generalized. Real product/spec names, GitHub source links, quickstart references, the reference IdP, and the TDF spec/schema itself are left intact. `otdfctl` / "OpenTDF CLI" references are out of scope (tracked under a separate CLI ticket).

## Changes

- **`docs/guides/subject-mapping-guide.md`** — 9 framing edits (intro, architecture description, diagram labels, admin/troubleshooting prose, FAQ). Kept: all `opentdf/platform` source links, the `opentdf-app` JSON example, and the Quickstart references.
- **`docs/components/`** — 3 framing edits: `key_access.md`, `policy/subject_mappings.md`, `policy/keymanagement/key_managers.md`.

## Assessed, no changes needed

- **`docs/spec/`** — every "OpenTDF" mention names the specification/format itself (spec title, "OpenTDF (Trusted Data Format)", reference implementation, schema paths). No-op, same finding as the SDK reference pages.
- **`docs/components/`** (remainder) — all other mentions are source links, `/spec/schema/opentdf/` paths, version references, and CLI references (deferred).

## Testing

- `npm run build` — succeeds (broken-anchor warnings are all pre-existing on untouched lines).
- `npm run check-vendored-yaml` — passes.
- Vale — no new findings on changed lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Key Access Server, key manager, and subject mapping documentation to use consistent platform terminology.
  * Refined the subject mapping guide’s architecture, scaling, troubleshooting, and FAQ language for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->