### PR TITLE
feat(ci): run quickstart stack test nightly with Slack failure alert

### DIFF
--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -15,6 +15,8 @@ on:
       - 'tests/**'
       - '.github/workflows/docker-compose-test.yml'
       - 'docs/getting-started/**'
+  schedule:
+    - cron: '17 6 * * *'
   workflow_dispatch:
 
 jobs:
@@ -197,3 +199,17 @@ jobs:
         run: |
           docker compose ps
           docker compose logs
+
+      - name: Notify Slack on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Quickstart stack test failed on nightly run"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ":red_circle: *Quickstart stack test failed*\nThe nightly docker-compose stack test is failing — the quickstart is broken for new users.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"


### PR DESCRIPTION
## Summary

The quickstart docker-compose stack test (`test-stack` in `docker-compose-test.yml`) currently only runs on push/PR to paths under `static/quickstart/`, `tests/`, and `docs/getting-started/`. Upstream breaking changes (e.g. opentdf/platform#3563) can silently break the quickstart for new users with no notification.

## Changes

1. **Nightly `schedule` trigger** — `cron: '17 6 * * *'` so the stack test runs daily.
2. **Slack notification on failure** — posts to `#alerts-opentdf`, scoped to scheduled runs only (`if: failure() && github.event_name == 'schedule'`).

## Prerequisite

A `SLACK_WEBHOOK_URL` repo secret must be added (Incoming Webhook for `#alerts-opentdf`). The Slack step is guarded to `schedule` events, so it never runs on PRs and the secret is not exposed to fork PRs.

Closes #355