### PR TITLE
DSPX-3636 update quickstart Keycloak docs

### DIFF
--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
   keycloak:
     volumes:
     - keys:/keys:ro
-    image: keycloak/keycloak:25.0
+    image: ghcr.io/opentdf/keycloak-standard:26.4.0
     restart: always
     depends_on:
       fix-keys-permissions:
@@ -106,10 +106,9 @@ services:
       KC_HTTP_PORT: "8888"
       KC_HTTPS_PORT: "8443"
       KC_HTTP_MANAGEMENT_PORT: "9001"
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: changeme
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: changeme
       #KC_HOSTNAME_URL: http://localhost:8888/auth
-      KC_FEATURES: "preview,token-exchange"
       KC_HEALTH_ENABLED: "true"
       KC_HTTPS_KEY_STORE_PASSWORD: "password"
       KC_HTTPS_KEY_STORE_FILE: "/keys/ca.jks"
@@ -569,4 +568,3 @@ volumes:
   caddy_data:
   platform_certs:
     name: opentdf_platform_certs
-

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
     - "-Djavax.net.ssl.trustStore=/keys/ca.jks"
     - "--spi-truststore-file-hostname-verification-policy=ANY"
     environment:
-      KC_PROXY: edge
+      KC_PROXY_HEADERS: xforwarded
       KC_HTTP_RELATIVE_PATH: /auth
       KC_HOSTNAME_STRICT: "false"
       KC_HOSTNAME_STRICT_BACKCHANNEL: "false"

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -109,6 +109,7 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: changeme
       #KC_HOSTNAME_URL: http://localhost:8888/auth
+      KC_FEATURES: "admin-fine-grained-authz:v1"
       KC_HEALTH_ENABLED: "true"
       KC_HTTPS_KEY_STORE_PASSWORD: "password"
       KC_HTTPS_KEY_STORE_FILE: "/keys/ca.jks"


### PR DESCRIPTION
## Summary
- update the getting started Docker Compose Keycloak image to 26.2
- switch the docs quickstart compose file to KC_BOOTSTRAP_ADMIN_* variables
- remove the deprecated preview token-exchange feature flag from the docs quickstart Keycloak service

## Context
Part of DSPX-3636. This mirrors the Keycloak 26 / standard token exchange work in opentdf/platform#3754.

## Testing
- not run; docs compose YAML-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Docker Compose Keycloak image to the latest standard release.
  - Adjusted proxy settings to use header-based configuration.
  - Revised Keycloak bootstrap administrator environment variables and enabled the updated authorization feature set.
  - Standardized the platform certificates volume name used by Docker Compose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->