### PR TITLE
docs(sdks): document TDF decrypt convenience helpers

### DIFF
--- a/code_samples/tdf/assertion_examples.mdx
+++ b/code_samples/tdf/assertion_examples.mdx
@@ -56,7 +56,7 @@ The system metadata assertion uses ID `"system-metadata"`, schema `"system-metad
 
 ### End-to-End Example
 
-Create a signed assertion at encrypt time, then verify it at decrypt time.
+Create a signed assertion at encrypt time, then verify it at decrypt time. Uses `LoadTDF` directly rather than the [Decrypt Helpers](/sdks/tdf#decrypt-helpers) (`DecryptBytes`/`DecryptTo`/`DecryptFile`), since this example reads `tdfReader.Manifest().Assertions` — the helpers return only the plaintext, with no access to manifest data.
 
 <Tabs>
 <TabItem value="go" label="Go">

--- a/docs/sdks/quickstart/go.mdx
+++ b/docs/sdks/quickstart/go.mdx
@@ -65,6 +65,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"strings"
 
@@ -122,7 +123,7 @@ func main() {
 
 	// Decrypt data
 	log.Println("\n🔓 Decrypting TDF...")
-	decryptedBytes, err := client.DecryptBytes(encryptedBuffer.Bytes())
+	decryptedBytes, err := client.DecryptBytes(context.Background(), encryptedBuffer.Bytes())
 	if err != nil {
 		log.Fatalf("❌ Decryption failed: %v", err)
 	}
@@ -400,7 +401,10 @@ In production applications, you'll often need to persist encrypted TDFs to disk 
 - **Archive encrypted data**: Store TDFs in backup systems or long-term storage with their access policies intact
 
 ```go
-import "os"
+import (
+	"context"
+	"os"
+)
 
 // After encryption
 err = os.WriteFile("encrypted.tdf", encryptedBuffer.Bytes(), 0644)
@@ -410,7 +414,7 @@ if err != nil {
 
 // Later, decrypt directly from the file — DecryptFile streams from disk
 // rather than buffering the ciphertext or plaintext in memory.
-err = client.DecryptFile("encrypted.tdf", "decrypted.txt")
+err = client.DecryptFile(context.Background(), "encrypted.tdf", "decrypted.txt")
 if err != nil {
 	log.Fatalf("Failed to decrypt TDF: %v", err)
 }
@@ -622,7 +626,7 @@ func main() {
 	log.Printf("✅ TDF loaded from encrypted.tdf")
 
 	// 7. Decrypt the data
-	decryptedBytes, err := client.DecryptBytes(tdfData)
+	decryptedBytes, err := client.DecryptBytes(context.Background(), tdfData)
 	if err != nil {
 		log.Fatalf("Failed to decrypt: %v", err)
 	}

--- a/docs/sdks/quickstart/go.mdx
+++ b/docs/sdks/quickstart/go.mdx
@@ -122,18 +122,13 @@ func main() {
 
 	// Decrypt data
 	log.Println("\n🔓 Decrypting TDF...")
-	tdfReader, err := client.LoadTDF(bytes.NewReader(encryptedBuffer.Bytes()))
+	decryptedBytes, err := client.DecryptBytes(encryptedBuffer.Bytes())
 	if err != nil {
 		log.Fatalf("❌ Decryption failed: %v", err)
 	}
 
-	var decryptedBuffer bytes.Buffer
-	if _, err = tdfReader.WriteTo(&decryptedBuffer); err != nil {
-		log.Fatalf("❌ Failed to read decrypted data: %v", err)
-	}
-
 	log.Println("✅ Data successfully decrypted")
-	log.Printf("📤 Decrypted content:\n\n%s\n", decryptedBuffer.String())
+	log.Printf("📤 Decrypted content:\n\n%s\n", string(decryptedBytes))
 
 	log.Println("\n🎉 Quickstart complete!")
 }
@@ -413,14 +408,15 @@ if err != nil {
 	log.Fatalf("Failed to save TDF: %v", err)
 }
 
-// Later, load from file
-tdfData, err := os.ReadFile("encrypted.tdf")
+// Later, decrypt directly from the file — DecryptFile streams from disk
+// rather than buffering the ciphertext or plaintext in memory.
+err = client.DecryptFile("encrypted.tdf", "decrypted.txt")
 if err != nil {
-	log.Fatalf("Failed to read TDF: %v", err)
+	log.Fatalf("Failed to decrypt TDF: %v", err)
 }
-
-tdfReader, err := client.LoadTDF(bytes.NewReader(tdfData))
 ```
+
+`DecryptFile` is one of three decrypt convenience helpers — see [Decrypt Helpers](/sdks/tdf#decrypt-helpers) for `DecryptBytes` and `DecryptTo`, which work directly on in-memory ciphertext instead of a file path.
 
 ### Handle Large Files with Streaming
 
@@ -626,19 +622,13 @@ func main() {
 	log.Printf("✅ TDF loaded from encrypted.tdf")
 
 	// 7. Decrypt the data
-	tdfReader, err := client.LoadTDF(bytes.NewReader(tdfData))
-	if err != nil {
-		log.Fatalf("Failed to load TDF: %v", err)
-	}
-
-	var decryptedBuffer bytes.Buffer
-	_, err = tdfReader.WriteTo(&decryptedBuffer)
+	decryptedBytes, err := client.DecryptBytes(tdfData)
 	if err != nil {
 		log.Fatalf("Failed to decrypt: %v", err)
 	}
 
 	log.Printf("✅ Data successfully decrypted")
-	log.Printf("📤 Decrypted content: %s", decryptedBuffer.String())
+	log.Printf("📤 Decrypted content: %s", string(decryptedBytes))
 }
 ```
 

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -19,6 +19,7 @@ This page covers the core TDF operations:
 
 - **[CreateTDF](#createtdf)** — encrypt a payload and write a TDF
 - **[LoadTDF](#loadtdf)** — open a TDF and access the plaintext
+- **[Decrypt Helpers](#decrypt-helpers)** — `DecryptBytes`/`DecryptTo`/`DecryptFile`: one-call convenience wrappers over `LoadTDF` + `WriteTo`
 - **[IsValidTdf](#isvalidtdf)** — check whether a stream is a valid TDF without decrypting
 - **[BulkDecrypt](#bulkdecrypt)** — decrypt multiple TDFs in one call
 - **[TDF Reader](#tdf-reader)** — methods on the reader object returned by `LoadTDF`
@@ -493,6 +494,99 @@ Rejects with `Error` if the TDF is invalid, the KAS is unreachable, access is de
 
 </TabItem>
 </Tabs>
+
+---
+
+## Decrypt Helpers
+
+Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common case of decrypting straight to plaintext.
+
+:::tip Why use these instead of LoadTDF directly?
+`LoadTDF` returns a reader — useful when you need to stream a very large payload or read manifest data (attributes, assertions) before writing out the payload. If you just want the plaintext, `DecryptBytes`, `DecryptTo`, and `DecryptFile` collapse `LoadTDF` + `WriteTo` into a single call.
+:::
+
+### DecryptBytes
+
+Decrypts a TDF payload held in memory and returns the plaintext.
+
+**Signature**
+
+```go
+func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, error)
+```
+
+**Example**
+
+```go
+plaintext, err := client.DecryptBytes(ciphertext)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(string(plaintext))
+```
+
+### DecryptTo
+
+Decrypts a TDF payload held in memory and writes the plaintext to any `io.Writer` — a file, `os.Stdout`, an HTTP response, etc.
+
+**Signature**
+
+```go
+func (s SDK) DecryptTo(out io.Writer, ciphertext []byte, opts ...TDFReaderOption) error
+```
+
+**Example**
+
+```go
+err := client.DecryptTo(os.Stdout, ciphertext)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### DecryptFile
+
+Decrypts the TDF at `inputPath` and writes the plaintext to `outputPath`. Streams directly from disk rather than buffering the whole ciphertext or plaintext in memory.
+
+**Signature**
+
+```go
+func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) error
+```
+
+**Example**
+
+```go
+err := client.DecryptFile("secret.tdf", "secret.txt")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+Plaintext is written to a temp file next to `outputPath` and only renamed into place once decryption fully succeeds — a pre-existing `outputPath` is never touched, truncated, or deleted if decryption fails partway. If `outputPath` already exists, it's moved aside and restored automatically if the final rename fails, so a failed decrypt never destroys a file that was already there. `inputPath` and `outputPath` must not refer to the same file (including via a hard link); `DecryptFile` rejects that case up front.
+
+**Errors**
+
+`DecryptBytes`, `DecryptTo`, and `DecryptFile` all wrap failures in one of two sentinels, so callers can branch on which stage failed regardless of which helper they called:
+
+| Error | Sentinel | Cause |
+|-------|----------|-------|
+| Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, or a schema validation failure. Retrying the same input won't help. |
+| Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
+
+Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`:
+
+```go
+plaintext, err := client.DecryptBytes(ciphertext)
+switch {
+case errors.Is(err, sdk.ErrTDFNotDecryptable):
+    // Pre-decrypt: the input itself isn't decryptable. Retrying won't help.
+case errors.Is(err, sdk.ErrTDFDecryptFailed):
+    // Decrypt-time: most commonly a KAS rewrap failure (not entitled).
+case err != nil:
+    // Some other failure (e.g. a writer error for DecryptTo/DecryptFile).
+}
+```
 
 ---
 

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -507,7 +507,7 @@ Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common ca
 
 ### DecryptBytes
 
-Decrypts a TDF payload held in memory and returns the plaintext.
+Decrypts a TDF payload held in memory and returns the plaintext. Rejects payloads over 1 GiB up front, before buffering anything, since the full plaintext is held in memory — use `DecryptTo` or `DecryptFile` for larger payloads, since both stream to their destination instead of buffering.
 
 **Signature**
 
@@ -571,7 +571,7 @@ Plaintext is written to a temp file next to `outputPath` and only renamed into p
 
 | Error | Sentinel | Cause |
 |-------|----------|-------|
-| Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, or a schema validation failure. Retrying the same input won't help. |
+| Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, a schema validation failure, or (for `DecryptBytes` only) a plaintext over the 1 GiB in-memory limit. Retrying the same input won't help. |
 | Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
 
 Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels — there's no third, uncategorized case:

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -507,7 +507,7 @@ Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common ca
 
 ### DecryptBytes
 
-Decrypts a TDF payload held in memory and returns the plaintext. Rejects payloads over 1 GiB up front, before buffering anything, since the full plaintext is held in memory — use `DecryptTo` or `DecryptFile` for larger payloads, since both stream to their destination instead of buffering.
+Decrypts a TDF payload held in memory and returns the plaintext.
 
 **Signature**
 
@@ -524,6 +524,8 @@ if err != nil {
 }
 fmt.Println(string(plaintext))
 ```
+
+**`DecryptBytes` caps plaintext at 1 GiB** and rejects anything larger up front, before buffering anything — unlike `DecryptTo`/`DecryptFile`, it holds the full plaintext in memory, so there's no way to safely handle bigger payloads through this call. Use `DecryptTo` or `DecryptFile` instead, since both stream to their destination rather than buffering.
 
 ### DecryptTo
 
@@ -574,7 +576,7 @@ Plaintext is written to a temp file next to `outputPath` and only renamed into p
 | Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, a schema validation failure, or (for `DecryptBytes` only) a plaintext over the 1 GiB in-memory limit. Retrying the same input won't help. |
 | Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
 
-Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels — there's no third, uncategorized case:
+Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. All three helpers only ever fail with one of these two sentinels:
 
 ```go
 plaintext, err := client.DecryptBytes(ciphertext)

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -499,7 +499,7 @@ Rejects with `Error` if the TDF is invalid, the KAS is unreachable, access is de
 
 ## Decrypt Helpers
 
-Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common case of decrypting straight to plaintext. All three accept the same `opts ...TDFReaderOption` as `LoadTDF` — see [Decrypt Options](#decrypt-options) for the full list.
+Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common case of decrypting straight to plaintext. All three take a `ctx context.Context` that governs their KAS rewrap request, and accept the same `opts ...TDFReaderOption` as `LoadTDF` — see [Decrypt Options](#decrypt-options) for the full list.
 
 :::tip Why use these instead of LoadTDF directly?
 `LoadTDF` returns a reader — useful when you need to stream a very large payload or read manifest data (attributes, assertions) before writing out the payload. If you just want the plaintext, `DecryptBytes`, `DecryptTo`, and `DecryptFile` collapse `LoadTDF` + `WriteTo` into a single call.
@@ -511,14 +511,16 @@ Decrypts a TDF payload held in memory and returns the plaintext. Rejects payload
 
 **Signature**
 
+<SdkVersion language="go" version="0.29.0" source="opentdf" />
+
 ```go
-func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, error)
+func (s SDK) DecryptBytes(ctx context.Context, ciphertext []byte, opts ...TDFReaderOption) ([]byte, error)
 ```
 
 **Example**
 
 ```go
-plaintext, err := client.DecryptBytes(ciphertext)
+plaintext, err := client.DecryptBytes(ctx, ciphertext)
 if err != nil {
     log.Fatal(err)
 }
@@ -531,14 +533,16 @@ Decrypts a TDF payload held in memory and writes the plaintext to any `io.Writer
 
 **Signature**
 
+<SdkVersion language="go" version="0.29.0" source="opentdf" />
+
 ```go
-func (s SDK) DecryptTo(out io.Writer, ciphertext []byte, opts ...TDFReaderOption) error
+func (s SDK) DecryptTo(ctx context.Context, out io.Writer, ciphertext []byte, opts ...TDFReaderOption) error
 ```
 
 **Example**
 
 ```go
-err := client.DecryptTo(os.Stdout, ciphertext)
+err := client.DecryptTo(ctx, os.Stdout, ciphertext)
 if err != nil {
     log.Fatal(err)
 }
@@ -550,14 +554,16 @@ Decrypts the TDF at `inputPath` and writes the plaintext to `outputPath`. Stream
 
 **Signature**
 
+<SdkVersion language="go" version="0.29.0" source="opentdf" />
+
 ```go
-func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) error
+func (s SDK) DecryptFile(ctx context.Context, inputPath, outputPath string, opts ...TDFReaderOption) error
 ```
 
 **Example**
 
 ```go
-err := client.DecryptFile("secret.tdf", "secret.txt")
+err := client.DecryptFile(ctx, "secret.tdf", "secret.txt")
 if err != nil {
     log.Fatal(err)
 }
@@ -575,10 +581,10 @@ Plaintext is written to a temp file next to `outputPath` and only renamed into p
 | Payload too large (`DecryptBytes` only) | `sdk.ErrTDFNotDecryptable` | Plaintext exceeds the 1 GiB in-memory limit. Use `DecryptTo`, `DecryptFile`, or `LoadTDF` directly instead. |
 | Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
 
-Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels — there's no third, uncategorized case:
+Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels:
 
 ```go
-plaintext, err := client.DecryptBytes(ciphertext)
+plaintext, err := client.DecryptBytes(ctx, ciphertext)
 switch {
 case errors.Is(err, sdk.ErrTDFNotDecryptable):
     // Pre-decrypt: the input itself isn't decryptable. Retrying won't help.

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -574,7 +574,7 @@ Plaintext is written to a temp file next to `outputPath` and only renamed into p
 | Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, or a schema validation failure. Retrying the same input won't help. |
 | Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
 
-Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`:
+Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels — there's no third, uncategorized case:
 
 ```go
 plaintext, err := client.DecryptBytes(ciphertext)
@@ -582,9 +582,7 @@ switch {
 case errors.Is(err, sdk.ErrTDFNotDecryptable):
     // Pre-decrypt: the input itself isn't decryptable. Retrying won't help.
 case errors.Is(err, sdk.ErrTDFDecryptFailed):
-    // Decrypt-time: most commonly a KAS rewrap failure (not entitled).
-case err != nil:
-    // Some other failure (e.g. a writer error for DecryptTo/DecryptFile).
+    // Decrypt-time: most commonly a KAS rewrap failure (not entitled), but also writer errors for DecryptTo/DecryptFile.
 }
 ```
 

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -507,7 +507,7 @@ Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common ca
 
 ### DecryptBytes
 
-Decrypts a TDF payload held in memory and returns the plaintext.
+Decrypts a TDF payload held in memory and returns the plaintext. Rejects payloads over 1 GiB up front, before buffering anything, since the full plaintext is held in memory — use `DecryptTo` or `DecryptFile` for larger payloads, since both stream to their destination instead of buffering.
 
 **Signature**
 
@@ -524,8 +524,6 @@ if err != nil {
 }
 fmt.Println(string(plaintext))
 ```
-
-**`DecryptBytes` caps plaintext at 1 GiB** and rejects anything larger up front, before buffering anything — unlike `DecryptTo`/`DecryptFile`, it holds the full plaintext in memory, so there's no way to safely handle bigger payloads through this call. Use `DecryptTo` or `DecryptFile` instead, since both stream to their destination rather than buffering.
 
 ### DecryptTo
 
@@ -576,7 +574,7 @@ Plaintext is written to a temp file next to `outputPath` and only renamed into p
 | Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, a schema validation failure, or (for `DecryptBytes` only) a plaintext over the 1 GiB in-memory limit. Retrying the same input won't help. |
 | Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
 
-Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. All three helpers only ever fail with one of these two sentinels:
+Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels — there's no third, uncategorized case:
 
 ```go
 plaintext, err := client.DecryptBytes(ciphertext)

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -571,7 +571,8 @@ Plaintext is written to a temp file next to `outputPath` and only renamed into p
 
 | Error | Sentinel | Cause |
 |-------|----------|-------|
-| Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, a schema validation failure, or (for `DecryptBytes` only) a plaintext over the 1 GiB in-memory limit. Retrying the same input won't help. |
+| Pre-decrypt failure | `sdk.ErrTDFNotDecryptable` | The input itself isn't decryptable — corrupt/invalid TDF bytes, a rejected `TDFReaderOption`, or a schema validation failure. Retrying the same input won't help. |
+| Payload too large (`DecryptBytes` only) | `sdk.ErrTDFNotDecryptable` | Plaintext exceeds the 1 GiB in-memory limit. Use `DecryptTo`, `DecryptFile`, or `LoadTDF` directly instead. |
 | Decrypt-time failure | `sdk.ErrTDFDecryptFailed` | Failed during decryption itself — most commonly a KAS rewrap failure (not entitled), but also writer errors or payload integrity errors. |
 
 Both are testable with `errors.Is`, and the underlying `LoadTDF`/`WriteTo` error stays reachable through the same chain via `errors.As`. Every failure from all three helpers wraps one of these two sentinels — there's no third, uncategorized case:

--- a/docs/sdks/tdf.mdx
+++ b/docs/sdks/tdf.mdx
@@ -499,7 +499,7 @@ Rejects with `Error` if the TDF is invalid, the KAS is unreachable, access is de
 
 ## Decrypt Helpers
 
-Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common case of decrypting straight to plaintext.
+Go-only convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common case of decrypting straight to plaintext. All three accept the same `opts ...TDFReaderOption` as `LoadTDF` — see [Decrypt Options](#decrypt-options) for the full list.
 
 :::tip Why use these instead of LoadTDF directly?
 `LoadTDF` returns a reader — useful when you need to stream a very large payload or read manifest data (attributes, assertions) before writing out the payload. If you just want the plaintext, `DecryptBytes`, `DecryptTo`, and `DecryptFile` collapse `LoadTDF` + `WriteTo` into a single call.


### PR DESCRIPTION
## Summary

Documents the new Go SDK `DecryptBytes`/`DecryptTo`/`DecryptFile` convenience helpers added in https://github.com/opentdf/platform/pull/3828.

- Adds a **Decrypt Helpers** section to `docs/sdks/tdf.mdx` (between `LoadTDF` and `IsValidTdf`): signatures, examples, `DecryptFile`'s temp-file/rename/backup-restore behavior, and an Errors table covering `ErrTDFNotDecryptable`/`ErrTDFDecryptFailed` with an `errors.Is` example.
- Updates `docs/sdks/quickstart/go.mdx` — all three places that manually did `LoadTDF` + `WriteTo` (the Step 3 running example, "Save TDF to a File", and the "Complete Reference Implementation") now use the new helpers.

Modeled on the existing `BulkDecrypt` section's structure (Go-only convenience methods don't need forced `<Tabs>` shells for Java/JS). Heading names (`DecryptBytes`/`DecryptTo`/`DecryptFile`) are unique across the page and its imported `code_samples/*.mdx` files, per the anchor-collision rule in `AGENTS.md`.

## Test plan

- [x] `vale docs/sdks/tdf.mdx docs/sdks/quickstart/go.mdx` — 0 errors, warnings, or suggestions.
- [x] Every code example and behavior claim cross-checked against the actual implementation in opentdf/platform#3828 (`sdk/decrypt.go`, `sdk/decrypterrors.go`).
- [x] Checked for heading/anchor collisions across `tdf.mdx` and its imports — none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified Go SDK quickstart examples for in-memory and file-based decryption.
  * Added guidance for decrypting data to memory, writers, and files.
  * Documented payload limits, streaming behavior, error classification, and file safety protections.
  * Clarified that manifest assertions are verified through the standard TDF loading flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->