### PR TITLE
fix(quickstart): update docker-compose.yaml on existing installations

### DIFF
--- a/static/quickstart/install.sh
+++ b/static/quickstart/install.sh
@@ -81,6 +81,27 @@ if [ -d "$OPENTDF_DIR" ]; then
     read -p "Do you want to reinstall? (y/N): " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        # Check if docker-compose.yaml needs updating
+        echo -e "${BLUE}→${NC} Checking for updates to docker-compose.yaml..."
+
+        if [ -f "$OPENTDF_DIR/docker-compose.yaml" ]; then
+            TEMP_COMPOSE=$(mktemp)
+            if curl -fsSL https://raw.githubusercontent.com/opentdf/docs/main/docs/getting-started/docker-compose.yaml -o "$TEMP_COMPOSE" 2>/dev/null; then
+                if ! cmp -s "$OPENTDF_DIR/docker-compose.yaml" "$TEMP_COMPOSE"; then
+                    echo -e "${YELLOW}→${NC} New version of docker-compose.yaml available"
+                    cp "$TEMP_COMPOSE" "$OPENTDF_DIR/docker-compose.yaml"
+                    echo -e "${GREEN}✓${NC} Updated docker-compose.yaml to latest version"
+                    echo -e "${BLUE}ℹ${NC}  You should restart your services to apply changes:"
+                    echo "     cd $OPENTDF_DIR && $COMPOSE_CMD down && $COMPOSE_CMD up -d"
+                else
+                    echo -e "${GREEN}✓${NC} docker-compose.yaml is up to date"
+                fi
+            else
+                echo -e "${YELLOW}⚠${NC} Could not check for updates (network issue)"
+            fi
+            rm -f "$TEMP_COMPOSE"
+        fi
+
         echo ""
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo -e "${GREEN}OpenTDF is already installed!${NC}"


### PR DESCRIPTION
## Summary

Fixes a bug where the quickstart install script fails to update `docker-compose.yaml` when run on existing installations, causing users to miss new services like `generate-pqc-keys`.

## Problem

When users run the install script on an existing installation:
1. The script detects the existing directory
2. Prompts "Do you want to reinstall? (y/N)"
3. When piped to bash or user answers "N", it exits without updating `docker-compose.yaml`
4. Users miss new services added to the compose file (like `generate-pqc-keys`)
5. Platform fails to start because code expects services that don't exist

## Solution

The script now automatically checks for and updates `docker-compose.yaml` when:
- An existing installation is detected
- User chooses not to reinstall (or script is piped to bash)

The update process:
- Downloads latest `docker-compose.yaml` to a temp file
- Compares it with the existing file
- Updates if different and notifies user to restart services
- Handles network errors gracefully
- Cleans up temp files

## Benefits

- Users get updates without losing Docker volumes
- No need for full reinstall to get new services
- Works with piped execution (`curl ... | bash`)
- Preserves existing data and configuration

## Testing

Tested with existing installation missing `generate-pqc-keys` service - script successfully detected and updated the compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved installation updates by detecting changes to the remote service configuration.
  * Replaces outdated local configuration files and reports whether an update was applied.
  * Advises users to restart services when configuration changes are detected.

* **Bug Fixes**
  * Installation now continues gracefully when the remote configuration cannot be reached.
  * Temporary update files are cleaned up automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->